### PR TITLE
Implement V2 Tactical Command and Warhacker HUD Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,8 @@
     <link rel="dns-prefetch" href="https://fonts.gstatic.com" />
     <link rel="preconnect" crossorigin="anonymous" href="https://fonts.googleapis.com" />
     <link rel="preconnect" crossorigin="anonymous" href="https://fonts.gstatic.com" />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Black+Ops+One&display=swap" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Black+Ops+One&family=Space+Grotesk:wght@300;400;500;600;700;900&family=Inter:wght@300;400;500;600;700;800;900&display=swap" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>War Dice</title>
   </head>

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "firebase": "^11.8.1",
         "pinia": "^2.1.4",
         "pinia-plugin-persistedstate": "^3.1.0",
+        "playwright": "^1.59.1",
         "vite": "^6.3.5",
         "vite-plugin-pwa": "^1.0.0",
         "vitest": "^3.2.4",
@@ -4805,6 +4806,18 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.18",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.18.tgz",
+      "integrity": "sha512-VSnGQAOLtP5mib/DPyg2/t+Tlv65NTBz83BJBJvmLVHHuKJVaDOBvJJykiT5TR++em5nfAySPccDZDa4oSrn8A==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/bidi-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
@@ -4853,9 +4866,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.24.5",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.5.tgz",
-      "integrity": "sha512-FDToo4Wo82hIdgc1CQ+NQD0hEhmpPjrZ3hiUgwgOG6IuTdlpr8jdjyG24P6cNP1yJpTLzS5OcGgSw0xmDU1/Tw==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "funding": [
         {
           "type": "opencollective",
@@ -4872,10 +4885,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001716",
-        "electron-to-chromium": "^1.5.149",
-        "node-releases": "^2.0.19",
-        "update-browserslist-db": "^1.1.3"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -5008,9 +5022,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001718",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001718.tgz",
-      "integrity": "sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==",
+      "version": "1.0.30001787",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001787.tgz",
+      "integrity": "sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==",
       "funding": [
         {
           "type": "opencollective",
@@ -5976,9 +5990,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.158",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.158.tgz",
-      "integrity": "sha512-9vcp2xHhkvraY6AHw2WMi+GDSLPX42qe2xjYaVoZqFRJiOcilVQFq9mZmpuHEQpzlgGDelKlV7ZiGcmMsc8WxQ==",
+      "version": "1.5.335",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.335.tgz",
+      "integrity": "sha512-q9n5T4BR4Xwa2cwbrwcsDJtHD/enpQ5S1xF1IAtdqf5AAgqDFmR/aakqH3ChFdqd/QXJhS3rnnXFtexU7rax6Q==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -9398,9 +9412,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+      "version": "2.0.37",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
       "license": "MIT"
     },
     "node_modules/nopt": {
@@ -9878,6 +9892,50 @@
         "pinia": "^2.0.0"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -9888,9 +9946,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
-      "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
+      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
       "funding": [
         {
           "type": "opencollective",
@@ -9907,7 +9965,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.8",
+        "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -12400,9 +12458,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "funding": [
         {
           "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "jsdoc-vuejs": "^4.0.0",
     "jsdom": "^27.4.0",
     "lint-staged": "^15.2.10",
+    "playwright": "^1.59.1",
     "postcss-html": "^1.5.0",
     "stylelint": "^15.10.1",
     "stylelint-config-recommended-vue": "^1.5.0",

--- a/src/components/warmachine/ScenarioMap.test.js
+++ b/src/components/warmachine/ScenarioMap.test.js
@@ -14,13 +14,14 @@ describe('ScenarioMap.vue', () => {
     // Scale is 12.5. 6 * 12.5 = 75. 11 * 12.5 = 137.5.
     const p1Zone = wrapper.find('.bg-player1')
     expect(p1Zone.exists()).toBe(true)
+    // p1 y = 600 - 75 = 525
     expect(p1Zone.attributes('height')).toBe('75')
+    expect(p1Zone.attributes('y')).toBe('525')
 
     const p2Zone = wrapper.find('.bg-player2')
     expect(p2Zone.exists()).toBe(true)
-    // p2 y = 600 - 137.5 = 462.5
     expect(p2Zone.attributes('height')).toBe('137.5')
-    expect(p2Zone.attributes('y')).toBe('462.5')
+    expect(p2Zone.attributes('y')).toBe('0')
   })
 
   it('renders objectives correctly', () => {

--- a/src/components/warmachine/ScenarioMap.vue
+++ b/src/components/warmachine/ScenarioMap.vue
@@ -7,25 +7,25 @@
     class="scenario-map"
   >
     <!-- Backgrounds -->
-    <rect class="bg-player2" x="0" y="0" width="600" :height="defenderDeployHeight" />
-    <rect class="bg-neutral" x="0" :y="defenderDeployHeight" width="600" :height="neutralHeight" />
-    <rect class="bg-player1" x="0" :y="600 - attackerDeployHeight" width="600" :height="attackerDeployHeight" />
+    <rect class="bg-player1" x="0" :y="600 - p1DeployHeight" width="600" :height="p1DeployHeight" />
+    <rect class="bg-neutral" x="0" :y="p2DeployHeight" width="600" :height="neutralHeight" />
+    <rect class="bg-player2" x="0" y="0" width="600" :height="p2DeployHeight" />
 
     <!-- Center Line -->
     <line x1="0" y1="300" x2="600" y2="300" stroke="#808080" stroke-width="2" stroke-dasharray="5 5" />
 
     <!-- Deployment Zone Labels -->
-    <text class="label-text" x="500" :y="defenderDeployHeight / 2 - 10">Defender</text>
-    <text class="label-text" x="500" :y="defenderDeployHeight / 2 + 10">Deployment Zone</text>
-    <text class="label-text" x="500" :y="600 - attackerDeployHeight / 2 - 10">Attacker</text>
-    <text class="label-text" x="500" :y="600 - attackerDeployHeight / 2 + 10">Deployment Zone</text>
+    <text class="label-text" x="500" :y="600 - p1DeployHeight / 2 - 10">Player 1</text>
+    <text class="label-text" x="500" :y="600 - p1DeployHeight / 2 + 10">Deployment Zone</text>
+    <text class="label-text" x="500" :y="p2DeployHeight / 2 - 10">Player 2</text>
+    <text class="label-text" x="500" :y="p2DeployHeight / 2 + 10">Deployment Zone</text>
 
     <!-- Deployment Measurements -->
-    <text class="measurement-text" x="70" :y="defenderDeployHeight / 2">{{ defenderDeploy }}"</text>
-    <line x1="50" y1="0" x2="50" :y2="defenderDeployHeight" stroke="white" stroke-width="4" stroke-dasharray="10 5" />
+    <text class="measurement-text" x="70" :y="600 - p1DeployHeight / 2">{{ p1Deploy }}"</text>
+    <line x1="50" :y1="600 - p1DeployHeight" x2="50" y2="600" stroke="white" stroke-width="4" stroke-dasharray="10 5" />
 
-    <text class="measurement-text" x="70" :y="600 - attackerDeployHeight / 2">{{ attackerDeploy }}"</text>
-    <line x1="50" :y1="600 - attackerDeployHeight" x2="50" y2="600" stroke="white" stroke-width="4" stroke-dasharray="10 5" />
+    <text class="measurement-text" x="70" :y="p2DeployHeight / 2">{{ p2Deploy }}"</text>
+    <line x1="50" y1="0" x2="50" :y2="p2DeployHeight" stroke="white" stroke-width="4" stroke-dasharray="10 5" />
 
     <!-- Objectives -->
     <g v-for="(obj, index) in computedObjectives" :key="index">
@@ -72,11 +72,11 @@
 import { computed } from 'vue'
 
 const props = defineProps({
-  attackerDeploy: {
+  p1Deploy: {
     type: Number,
     default: 6
   },
-  defenderDeploy: {
+  p2Deploy: {
     type: Number,
     default: 11
   },
@@ -87,16 +87,16 @@ const props = defineProps({
 })
 
 const SCALE = 12.5 // units per inch
-const OBJECTIVE__ATTACKER_COLOR = 'red'
-const OBJECTIVE__ATTACKER_FILL_COLOR = '#505050'
-const OBJECTIVE__defender_COLOR = 'blue'
-const OBJECTIVE__defender_FILL_COLOR = '#a7a7a7'
+const OBJECTIVE_P1_COLOR = 'red'
+const OBJECTIVE_P1_FILL_COLOR = '#505050'
+const OBJECTIVE_P2_COLOR = 'blue'
+const OBJECTIVE_P2_FILL_COLOR = '#a7a7a7'
 const OBJECTIVE_NEUTRAL_COLOR = 'black'
 const OBJECTIVE_NEUTRAL_FILL_COLOR = '#303030'
 
-const attackerDeployHeight = computed(() => props.attackerDeploy * SCALE)
-const defenderDeployHeight = computed(() => props.defenderDeploy * SCALE)
-const neutralHeight = computed(() => 600 - attackerDeployHeight.value - defenderDeployHeight.value)
+const p1DeployHeight = computed(() => props.p1Deploy * SCALE)
+const p2DeployHeight = computed(() => props.p2Deploy * SCALE)
+const neutralHeight = computed(() => 600 - p1DeployHeight.value - p2DeployHeight.value)
 
 const computedObjectives = computed(() => {
   return props.objectives.map(obj => {
@@ -193,9 +193,9 @@ const computedObjectives = computed(() => {
     let fillStyle = {}
 
     if (owner === 'p1' || owner === 'attacker') {
-      fillStyle = { fill: OBJECTIVE__ATTACKER_FILL_COLOR, stroke: OBJECTIVE__ATTACKER_COLOR }
+      fillStyle = { fill: OBJECTIVE_P1_FILL_COLOR, stroke: OBJECTIVE_P1_COLOR }
     } else if (owner === 'p2' || owner === 'defender') {
-      fillStyle = { fill: OBJECTIVE__defender_FILL_COLOR, stroke: OBJECTIVE__defender_COLOR }
+      fillStyle = { fill: OBJECTIVE_P2_FILL_COLOR, stroke: OBJECTIVE_P2_COLOR }
     } else {
       fillStyle = { fill: OBJECTIVE_NEUTRAL_FILL_COLOR, stroke: OBJECTIVE_NEUTRAL_COLOR }
       if (['40mm', '50mm'].includes(obj.type)) {

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -1,6 +1,25 @@
 const IndexPage = () => import('@/views/IndexPage.vue')
 const GamesPage = () => import('@/views/GamesPage.vue')
 
+// V2 Layouts
+const TacticalLayout = () => import('@/views/v2/tactical/TacticalLayout.vue')
+const WarhackerLayout = () => import('@/views/v2/warhacker/WarhackerLayout.vue')
+
+// V2 Tactical Pages
+const TacticalFactions = () => import('@/views/v2/tactical/FactionsPage.vue')
+const TacticalBuilder = () => import('@/views/v2/tactical/ArmyBuilderPage.vue')
+const TacticalSummary = () => import('@/views/v2/tactical/SummaryPage.vue')
+const TacticalUnit = () => import('@/views/v2/tactical/UnitDetailPage.vue')
+const TacticalUnitV2 = () => import('@/views/v2/tactical/UnitDetailPageV2.vue')
+const TacticalGame = () => import('@/views/v2/tactical/GamePage.vue')
+
+// V2 Warhacker Pages
+const WarhackerFactions = () => import('@/views/v2/warhacker/FactionsPage.vue')
+const WarhackerBuilder = () => import('@/views/v2/warhacker/ArmyBuilderPage.vue')
+const WarhackerHome = () => import('@/views/v2/warhacker/HomePage.vue')
+const WarhackerUnit = () => import('@/views/v2/warhacker/UnitDetailPage.vue')
+const WarhackerIntel = () => import('@/views/v2/warhacker/IntelPage.vue')
+
 export const routes = [
   {
     path: '/',
@@ -11,5 +30,30 @@ export const routes = [
     path: '/games',
     name: 'Games',
     component: GamesPage
+  },
+  {
+    path: '/v2/tactical',
+    component: TacticalLayout,
+    children: [
+      { path: '', redirect: 'factions' },
+      { path: 'factions', name: 'TacticalFactions', component: TacticalFactions },
+      { path: 'builder', name: 'TacticalBuilder', component: TacticalBuilder },
+      { path: 'summary', name: 'TacticalSummary', component: TacticalSummary },
+      { path: 'unit', name: 'TacticalUnit', component: TacticalUnit },
+      { path: 'unit-v2', name: 'TacticalUnitV2', component: TacticalUnitV2 },
+      { path: 'game', name: 'TacticalGame', component: TacticalGame }
+    ]
+  },
+  {
+    path: '/v2/warhacker',
+    component: WarhackerLayout,
+    children: [
+      { path: '', redirect: 'home' },
+      { path: 'home', name: 'WarhackerHome', component: WarhackerHome },
+      { path: 'factions', name: 'WarhackerFactions', component: WarhackerFactions },
+      { path: 'builder', name: 'WarhackerBuilder', component: WarhackerBuilder },
+      { path: 'unit', name: 'WarhackerUnit', component: WarhackerUnit },
+      { path: 'intel', name: 'WarhackerIntel', component: WarhackerIntel }
+    ]
   }
 ]

--- a/src/style.v2.css
+++ b/src/style.v2.css
@@ -1,0 +1,86 @@
+@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700;800;900&family=Inter:wght@300;400;500;600;700;800;900&display=swap');
+
+:root {
+  /* V2 COLOR VARIABLES */
+  --v2-primary: #4fd7f0;
+  --v2-on-primary: #00363e;
+  --v2-primary-container: #00b2ca;
+  --v2-on-primary-container: #003f48;
+  --v2-primary-fixed: #a3eeff;
+  --v2-primary-fixed-dim: #4fd7f0;
+  --v2-on-primary-fixed: #001f25;
+  --v2-on-primary-fixed-variant: #004e5a;
+
+  --v2-secondary: #ffb68b;
+  --v2-on-secondary: #522300;
+  --v2-secondary-container: #ff7f1c;
+  --v2-on-secondary-container: #602a00;
+  --v2-secondary-fixed: #ffdbc8;
+  --v2-secondary-fixed-dim: #ffb68b;
+  --v2-on-secondary-fixed: #321200;
+  --v2-on-secondary-fixed-variant: #753400;
+
+  --v2-tertiary: #00daf3;
+  --v2-on-tertiary: #00363d;
+  --v2-tertiary-container: #00b2c7;
+  --v2-on-tertiary-container: #003f47;
+  --v2-tertiary-fixed: #9cf0ff;
+  --v2-tertiary-fixed-dim: #00daf3;
+  --v2-on-tertiary-fixed: #001f24;
+  --v2-on-tertiary-fixed-variant: #004f58;
+
+  --v2-error: #ffb4ab;
+  --v2-on-error: #690005;
+  --v2-error-container: #93000a;
+  --v2-on-error-container: #ffdad6;
+
+  --v2-surface: #001620;
+  --v2-on-surface: #cbe7f7;
+  --v2-surface-variant: #1e3845;
+  --v2-on-surface-variant: #bcc9cc;
+  --v2-surface-bright: #223c49;
+  --v2-surface-dim: #001620;
+  --v2-surface-container-lowest: #001019;
+  --v2-surface-container-low: #011e2a;
+  --v2-surface-container: #05222f;
+  --v2-surface-container-high: #122d39;
+  --v2-surface-container-highest: #1e3845;
+
+  --v2-outline: #869396;
+  --v2-outline-variant: #3c494c;
+  --v2-inverse-surface: #cbe7f7;
+  --v2-inverse-on-surface: #193440;
+  --v2-inverse-primary: #006877;
+  --v2-surface-tint: #4fd7f0;
+
+  --v2-background: #001620;
+  --v2-on-background: #cbe7f7;
+
+  /* FONTS VARIABLES */
+  --v2-font-headline: 'Space Grotesk', sans-serif;
+  --v2-font-body: 'Inter', sans-serif;
+  --v2-font-label: 'Space Grotesk', sans-serif;
+}
+
+.v2-theme {
+  background-color: var(--v2-background);
+  color: var(--v2-on-surface);
+  font-family: var(--v2-font-body);
+  min-height: 100vh;
+}
+
+.v2-theme .font-headline {
+  font-family: var(--v2-font-headline);
+}
+
+.v2-theme .font-body {
+  font-family: var(--v2-font-body);
+}
+
+.v2-theme .font-label {
+  font-family: var(--v2-font-label);
+}
+
+.v2-theme .material-symbols-outlined {
+  font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+}

--- a/src/views/v2/tactical/ArmyBuilderPage.vue
+++ b/src/views/v2/tactical/ArmyBuilderPage.vue
@@ -1,0 +1,785 @@
+<template>
+  <div class="v2-builder-page">
+    <!-- Header Branding Section -->
+    <header class="v2-builder-header">
+      <div class="v2-builder-title-row">
+        <h1 class="font-headline v2-builder-main-title">DARK HOST</h1>
+        <span class="font-headline v2-builder-subtitle">Cryx Theme Force</span>
+      </div>
+      <div class="v2-builder-quote">
+        "The dead do not rest in the service of the Dragon Father. They march, a tide of bone and iron, to claim the souls of the living."
+      </div>
+      <div class="v2-builder-header-glow"></div>
+    </header>
+
+    <div class="v2-builder-grid">
+      <!-- Main Builder Canvas -->
+      <div class="v2-builder-main">
+        <!-- Warcaster Section -->
+        <section class="v2-builder-section">
+          <div class="v2-section-header">
+            <h2 class="font-headline v2-section-title">
+              <span class="material-symbols-outlined v2-section-icon">person</span> Warcasters
+            </h2>
+            <span class="v2-section-meta">1 / 1 Required</span>
+          </div>
+          <!-- Unit Card: The Wraith Witch -->
+          <div class="v2-unit-card-large">
+            <div class="card-wj-badge">+28 WJ</div>
+            <div class="v2-card-row">
+              <div class="card-portrait-v2">
+                <img alt="Wraith Witch" class="v2-img-cover" src="https://lh3.googleusercontent.com/aida-public/AB6AXuD04MsB4eRs2NJf36dgs4NMspXEp_0g2LMsXfQ9U6VbiOTTzpNayI8rdZC_7CFbFa2dlOAhzjP2uHlnOc1wTe0PWGQbjO7ZvwsuOXpckwauaZEdI32TD3CE32AsqPNooohj4V9vKWblUQeSPE2-1e8LaiSBIsqO4W52GBrbaFuFMqeAUBr59TaXvO3oKUXK5hUYWtfQbzcOwGTG3ZhJCV8CQf3oAIRJJdVvKXdo7FBzCHTieIAORGYn29zF2EclXDAEWRUuaz5O72xY"/>
+              </div>
+              <div class="v2-card-content-v2">
+                <div>
+                  <h3 class="font-headline v2-unit-name">The Wraith Witch Deneghra</h3>
+                  <div class="v2-tag-row">
+                    <span class="v2-tag tag-primary">Witch</span>
+                    <span class="v2-tag tag-secondary">Epic</span>
+                  </div>
+                </div>
+                <div class="v2-stat-row">
+                  <div class="v2-stat-group">
+                    <div class="stat-label">SPD</div>
+                    <div class="stat-value">7</div>
+                  </div>
+                  <div class="v2-stat-group">
+                    <div class="stat-label">DEF</div>
+                    <div class="stat-value">16</div>
+                  </div>
+                  <div class="v2-stat-group">
+                    <div class="stat-label">ARM</div>
+                    <div class="stat-value">14</div>
+                  </div>
+                  <div class="v2-stat-group">
+                    <div class="stat-label">FOC</div>
+                    <div class="stat-value">7</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <!-- Warjacks Section -->
+        <section class="v2-builder-section">
+          <div class="v2-section-header">
+            <h2 class="font-headline v2-section-title">
+              <span class="material-symbols-outlined v2-section-icon">settings_slow_motion</span> Warjacks
+            </h2>
+            <span class="v2-section-meta">Points remaining: 12</span>
+          </div>
+          <div class="v2-grid-jack">
+            <!-- Unit Card: Deathjack -->
+            <div class="v2-jack-card">
+              <div class="v2-jack-card-content">
+                <div class="v2-jack-info-row">
+                  <div class="jack-icon-box">
+                    <span class="material-symbols-outlined v2-jack-icon">skull</span>
+                  </div>
+                  <div>
+                    <h4 class="font-headline v2-jack-name">Deathjack</h4>
+                    <p class="v2-jack-type">Character Heavy Warjack</p>
+                    <div class="v2-damage-dots">
+                      <div class="v2-dot filled"></div>
+                      <div class="v2-dot filled"></div>
+                      <div class="v2-dot empty"></div>
+                    </div>
+                  </div>
+                </div>
+                <div class="jack-pts-badge">19</div>
+              </div>
+            </div>
+            <!-- Unit Card: Deathripper -->
+            <div class="v2-jack-card">
+              <div class="v2-jack-card-content">
+                <div class="v2-jack-info-row">
+                  <div class="jack-icon-box">
+                    <span class="material-symbols-outlined v2-jack-icon">bolt</span>
+                  </div>
+                  <div>
+                    <h4 class="font-headline v2-jack-name">Deathripper</h4>
+                    <p class="v2-jack-type">Bonejack Arc Node</p>
+                    <div class="v2-damage-dots">
+                      <div class="v2-dot filled"></div>
+                      <div class="v2-dot filled"></div>
+                      <div class="v2-dot filled"></div>
+                    </div>
+                  </div>
+                </div>
+                <div class="jack-pts-badge">6</div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <!-- Units Section (Bento Style) -->
+        <section class="v2-builder-section">
+          <div class="v2-section-header">
+            <h2 class="font-headline v2-section-title">
+              <span class="material-symbols-outlined v2-section-icon">groups</span> Units
+            </h2>
+          </div>
+          <div class="v2-unit-bento">
+            <div class="v2-unit-bento-large">
+              <div class="bento-bg-icon">
+                <span class="material-symbols-outlined v2-giant-icon">mist</span>
+              </div>
+              <div class="v2-bento-top-row">
+                <div>
+                  <h3 class="font-headline v2-bento-title">Bane Warriors</h3>
+                  <p class="v2-bento-subtitle">10 Models | Dark Host Specialty</p>
+                </div>
+                <div class="pts-badge-large">16</div>
+              </div>
+              <div class="v2-bento-footer">
+                <div class="v2-mini-icons">
+                  <div class="mini-icon-circle overlap"><span class="material-symbols-outlined">swords</span></div>
+                  <div class="mini-icon-circle overlap"><span class="material-symbols-outlined">shield</span></div>
+                  <div class="mini-icon-circle"><span class="material-symbols-outlined">skull</span></div>
+                </div>
+                <span class="font-headline v2-bento-rules">Vengeance, Ghostly, Void Weapon</span>
+              </div>
+            </div>
+            <div class="v2-unit-bento-add">
+              <span class="material-symbols-outlined v2-add-icon">add_circle</span>
+              <span class="font-headline v2-add-label">Add New Unit</span>
+            </div>
+          </div>
+        </section>
+      </div>
+
+      <!-- Right Sidebar: Summary & Validation -->
+      <aside class="v2-builder-sidebar">
+        <div class="v2-sidebar-section">
+          <h2 class="font-headline v2-sidebar-title">Army Stats</h2>
+          <div class="v2-stats-stack">
+            <!-- Point Counter -->
+            <div class="stat-card border-primary">
+              <div class="stat-card-header">
+                <span class="font-headline stat-card-label">Points Used</span>
+                <span class="font-headline stat-card-value-main">41 <span class="stat-card-total">/ 75</span></span>
+              </div>
+              <div class="v2-progress-bg">
+                <div class="v2-progress-bar bg-primary" :style="{ width: '55%' }"></div>
+              </div>
+            </div>
+            <!-- WJ Counter -->
+            <div class="stat-card border-tertiary">
+              <div class="stat-card-header">
+                <span class="font-headline stat-card-label">Warjack Points</span>
+                <span class="font-headline stat-card-value-tertiary">25 <span class="stat-card-total">/ 28</span></span>
+              </div>
+              <div class="v2-progress-bg">
+                <div class="v2-progress-bar bg-tertiary" :style="{ width: '89%' }"></div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="v2-sidebar-section">
+          <h2 class="font-headline v2-sidebar-title">Diagnostics</h2>
+          <div class="v2-diagnostic-stack">
+            <div class="v2-diagnostic-box diagnostic-error flicker-alert">
+              <div class="v2-diagnostic-content">
+                <span class="material-symbols-outlined v2-diagnostic-icon">warning</span>
+                <div>
+                  <div class="font-headline v2-diagnostic-title">Command Limit Breach</div>
+                  <p class="v2-diagnostic-desc">Bane Warriors require an officer or solo attachment for theme bonus.</p>
+                </div>
+              </div>
+            </div>
+            <div class="v2-diagnostic-box diagnostic-success">
+              <div class="v2-diagnostic-content">
+                <span class="material-symbols-outlined v2-diagnostic-icon">check_circle</span>
+                <div>
+                  <div class="font-headline v2-diagnostic-title">Theme Valid</div>
+                  <p class="v2-diagnostic-desc">Dark Host requirements satisfied.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="v2-builder-actions">
+          <button class="v2-button v2-button-outline v2-action-btn">
+            EXPORT LIST
+          </button>
+          <button class="v2-button v2-button-primary v2-deploy-btn">
+            DEPLOY ARMY
+          </button>
+        </div>
+      </aside>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.v2-builder-page {
+  padding: 0;
+}
+
+.v2-builder-header {
+  margin-bottom: 32px;
+  position: relative;
+  padding: 24px 0;
+}
+
+.v2-builder-title-row {
+  display: flex;
+  align-items: baseline;
+  gap: 16px;
+}
+
+.v2-builder-main-title {
+  font-size: 48px;
+  font-weight: 900;
+  letter-spacing: -0.05em;
+  text-transform: uppercase;
+  color: var(--v2-on-surface);
+}
+
+.v2-builder-subtitle {
+  color: var(--v2-primary);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  font-size: 14px;
+  border-left: 1px solid rgba(8, 71, 93, 0.5);
+  padding-left: 16px;
+}
+
+.v2-builder-quote {
+  margin-top: 8px;
+  color: #94a3b8;
+  font-size: 14px;
+  max-width: 672px;
+  font-weight: 300;
+  font-style: italic;
+}
+
+.v2-builder-header-glow {
+  position: absolute;
+  z-index: -10;
+  top: 0;
+  right: 0;
+  width: 256px;
+  height: 256px;
+  background-color: rgba(79, 215, 240, 0.05);
+  filter: blur(100px);
+  pointer-events: none;
+}
+
+.v2-builder-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 32px;
+}
+
+@media (min-width: 1024px) {
+  .v2-builder-grid {
+    grid-template-columns: repeat(12, 1fr);
+  }
+  .v2-builder-main {
+    grid-column: span 8;
+  }
+  .v2-builder-sidebar {
+    grid-column: span 4;
+    position: sticky;
+    top: 96px;
+    height: fit-content;
+  }
+}
+
+.v2-builder-section {
+  margin-bottom: 32px;
+}
+
+.v2-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid rgba(60, 73, 76, 0.3);
+  padding-bottom: 8px;
+  margin-bottom: 16px;
+}
+
+.v2-section-title {
+  font-weight: 700;
+  font-size: 18px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--v2-primary);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.v2-section-icon {
+  font-size: 14px;
+}
+
+.v2-section-meta {
+  font-size: 10px;
+  color: #64748b;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.v2-unit-card-large {
+  background-color: var(--v2-surface-container);
+  border-top: 1px solid rgba(79, 215, 240, 0.3);
+  position: relative;
+  transition: background-color 0.3s ease;
+}
+
+.v2-unit-card-large:hover {
+  background-color: var(--v2-surface-container-high);
+}
+
+.card-wj-badge {
+  position: absolute;
+  top: 0;
+  right: 0;
+  background-color: var(--v2-primary-container);
+  color: var(--v2-on-primary-container);
+  padding: 4px 12px;
+  font-family: var(--v2-font-headline);
+  font-weight: 900;
+  font-size: 12px;
+  z-index: 10;
+}
+
+.v2-card-row {
+  display: flex;
+  height: 128px;
+}
+
+.card-portrait-v2 {
+  width: 128px;
+  height: 100%;
+  overflow: hidden;
+  filter: grayscale(1);
+  transition: filter 0.5s ease;
+}
+
+.v2-img-cover {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.v2-unit-card-large:hover .card-portrait-v2 {
+  filter: grayscale(0);
+}
+
+.v2-card-content-v2 {
+  flex: 1;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  box-sizing: border-box;
+}
+
+.v2-unit-name {
+  font-weight: 900;
+  font-size: 20px;
+  text-transform: uppercase;
+  letter-spacing: -0.05em;
+  color: var(--v2-on-surface);
+}
+
+.v2-tag-row {
+  display: flex;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.v2-tag {
+  font-size: 10px;
+  padding: 2px 8px;
+  text-transform: uppercase;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  background-color: var(--v2-surface-container-highest);
+}
+
+.tag-primary { color: var(--v2-primary); }
+.tag-secondary { color: var(--v2-secondary); }
+
+.v2-stat-row {
+  display: flex;
+  gap: 24px;
+}
+
+.v2-stat-group {
+  text-align: center;
+}
+
+.stat-label { font-size: 9px; color: #64748b; text-transform: uppercase; font-family: var(--v2-font-headline); }
+.stat-value { font-family: var(--v2-font-headline); font-weight: 700; color: var(--v2-tertiary); font-size: 16px; }
+
+.v2-grid-jack {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 16px;
+}
+
+@media (min-width: 768px) {
+  .v2-grid-jack {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.v2-jack-card {
+  background-color: var(--v2-surface-container);
+  border-top: 1px solid rgba(60, 73, 76, 0.2);
+  transition: all 0.3s ease;
+}
+
+.v2-jack-card:hover {
+  border-top-color: rgba(79, 215, 240, 0.4);
+}
+
+.v2-jack-card-content {
+  display: flex;
+  padding: 16px;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.v2-jack-info-row {
+  display: flex;
+  gap: 16px;
+}
+
+.jack-icon-box {
+  width: 64px;
+  height: 64px;
+  background-color: var(--v2-surface-container-highest);
+  border: 1px solid rgba(8, 71, 93, 0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.v2-jack-icon {
+  color: var(--v2-primary);
+  font-size: 30px;
+}
+
+.v2-jack-name {
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: -0.025em;
+}
+
+.v2-jack-type {
+  font-size: 10px;
+  color: #64748b;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.v2-damage-dots {
+  margin-top: 8px;
+  display: flex;
+  gap: 4px;
+}
+
+.v2-dot {
+  width: 8px;
+  height: 8px;
+}
+
+.v2-dot.filled { background-color: var(--v2-primary); }
+.v2-dot.empty { background-color: rgba(79, 215, 240, 0.2); }
+
+.jack-pts-badge {
+  background-color: var(--v2-surface-container-highest);
+  color: var(--v2-tertiary);
+  padding: 4px 8px;
+  font-family: var(--v2-font-headline);
+  font-weight: 700;
+  font-size: 14px;
+}
+
+.v2-unit-bento {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 16px;
+}
+
+.v2-unit-bento-large {
+  grid-column: span 12;
+  background-color: var(--v2-surface-container);
+  padding: 24px;
+  border-top: 1px solid rgba(79, 215, 240, 0.3);
+  height: 192px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  position: relative;
+  overflow: hidden;
+  box-sizing: border-box;
+}
+
+@media (min-width: 768px) {
+  .v2-unit-bento-large {
+    grid-column: span 8;
+  }
+}
+
+.bento-bg-icon {
+  position: absolute;
+  right: -16px;
+  top: 50%;
+  transform: translateY(-50%);
+  opacity: 0.05;
+  pointer-events: none;
+}
+
+.v2-giant-icon {
+  font-size: 200px;
+  font-variation-settings: 'FILL' 1;
+}
+
+.v2-bento-top-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  position: relative;
+  z-index: 1;
+}
+
+.v2-bento-title {
+  font-weight: 900;
+  font-size: 24px;
+  text-transform: uppercase;
+  letter-spacing: -0.05em;
+}
+
+.v2-bento-subtitle {
+  color: #94a3b8;
+  text-transform: uppercase;
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  margin-top: 4px;
+}
+
+.pts-badge-large {
+  background-color: var(--v2-primary-container);
+  color: var(--v2-on-primary-container);
+  padding: 4px 16px;
+  font-family: var(--v2-font-headline);
+  font-weight: 900;
+  font-size: 18px;
+}
+
+.v2-bento-footer {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  position: relative;
+  z-index: 1;
+}
+
+.v2-mini-icons {
+  display: flex;
+}
+
+.mini-icon-circle {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 1px solid var(--v2-surface);
+  background-color: var(--v2-surface-container-highest);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.mini-icon-circle.overlap {
+  margin-right: -8px;
+}
+
+.v2-bento-rules {
+  font-size: 12px;
+  color: #64748b;
+  text-transform: uppercase;
+  font-weight: 700;
+}
+
+.v2-unit-bento-add {
+  grid-column: span 12;
+  background-color: var(--v2-surface-container-low);
+  border: 2px dashed rgba(60, 73, 76, 0.3);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  color: #64748b;
+  transition: all 0.3s ease;
+  cursor: pointer;
+  padding: 24px;
+  box-sizing: border-box;
+}
+
+@media (min-width: 768px) {
+  .v2-unit-bento-add {
+    grid-column: span 4;
+  }
+}
+
+.v2-unit-bento-add:hover {
+  border-color: rgba(79, 215, 240, 0.5);
+  color: var(--v2-primary);
+}
+
+.v2-add-icon {
+  font-size: 36px;
+  margin-bottom: 8px;
+}
+
+.v2-add-label {
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 12px;
+}
+
+.v2-sidebar-section {
+  margin-bottom: 40px;
+}
+
+.v2-sidebar-title {
+  font-size: 12px;
+  font-weight: 900;
+  color: #64748b;
+  text-transform: uppercase;
+  letter-spacing: 0.3em;
+  margin-bottom: 24px;
+}
+
+.v2-stats-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.stat-card {
+  background-color: var(--v2-surface-container-low);
+  padding: 16px;
+  border-top: 2px solid transparent;
+}
+
+.stat-card.border-primary { border-top-color: var(--v2-primary); }
+.stat-card.border-tertiary { border-top-color: var(--v2-tertiary); }
+
+.stat-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  margin-bottom: 4px;
+}
+
+.stat-card-label {
+  font-size: 12px;
+  font-weight: 700;
+  color: #94a3b8;
+  text-transform: uppercase;
+}
+
+.stat-card-value-main {
+  font-size: 24px;
+  font-weight: 900;
+  color: var(--v2-primary);
+}
+
+.stat-card-value-tertiary {
+  font-size: 24px;
+  font-weight: 900;
+  color: var(--v2-tertiary);
+}
+
+.stat-card-total {
+  font-size: 14px;
+  color: #64748b;
+  font-weight: 400;
+}
+
+.v2-progress-bg {
+  width: 100%;
+  height: 4px;
+  background-color: var(--v2-surface-container-highest);
+}
+
+.v2-progress-bar {
+  height: 100%;
+}
+
+.bg-primary { background-color: var(--v2-primary); }
+.bg-tertiary { background-color: var(--v2-tertiary); }
+
+.v2-diagnostic-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.v2-diagnostic-box {
+  padding: 12px;
+  border-left-width: 4px;
+  border-left-style: solid;
+}
+
+.diagnostic-error {
+  background-color: rgba(147, 0, 10, 0.1);
+  border-left-color: var(--v2-error);
+  color: var(--v2-error);
+}
+
+.diagnostic-success {
+  background-color: rgba(8, 71, 93, 0.1);
+  border-left-color: var(--v2-primary);
+  color: var(--v2-primary);
+}
+
+.v2-diagnostic-content {
+  display: flex;
+  gap: 12px;
+}
+
+.v2-diagnostic-icon {
+  font-size: 14px;
+}
+
+.v2-diagnostic-title {
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.v2-diagnostic-desc {
+  font-size: 10px;
+  margin-top: 4px;
+  text-transform: uppercase;
+  font-weight: 600;
+  opacity: 0.8;
+}
+
+.v2-builder-actions {
+  padding-top: 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.v2-action-btn {
+  padding: 12px;
+  font-size: 12px;
+}
+
+.v2-deploy-btn {
+  padding: 16px;
+  font-size: 14px;
+}
+</style>

--- a/src/views/v2/tactical/FactionsPage.vue
+++ b/src/views/v2/tactical/FactionsPage.vue
@@ -1,0 +1,210 @@
+<template>
+  <div class="v2-factions-page">
+    <!-- Dashboard Header -->
+    <div class="v2-page-header">
+      <h1 class="font-headline v2-title-main">Select <span class="v2-text-italic">Faction</span></h1>
+      <div class="v2-header-accent">
+        <div class="v2-accent-line"></div>
+        <p class="font-label v2-header-subtitle">Deploy your arcane legion to the frontlines</p>
+      </div>
+    </div>
+    <!-- Faction Bento Grid -->
+    <div class="faction-bento-grid">
+      <div v-for="faction in factions" :key="faction.id" class="faction-card-v2 chiseled-top inner-glow">
+        <div class="card-gradient-overlay"></div>
+        <img :alt="faction.name" class="card-bg-image" :src="faction.image"/>
+        <div class="card-content-v2">
+          <div class="card-top-right">
+            <div class="faction-code-badge">{{ faction.code }}</div>
+          </div>
+          <div class="faction-info-box">
+            <div class="faction-type-row">
+              <span class="material-symbols-outlined faction-type-icon">{{ faction.icon }}</span>
+              <span class="font-label faction-type-label">{{ faction.type }}</span>
+            </div>
+            <h3 class="font-headline faction-name-v2">{{ faction.name }}</h3>
+          </div>
+          <p class="font-body faction-desc-v2">{{ faction.description }}</p>
+          <button class="v2-button v2-button-outline faction-btn-v2">Initialize Command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+const factions = [
+  { id: 1, name: 'Cryx', code: 'CRX', type: 'Necro-Industrial', icon: 'skull', description: 'The Nightmare Empire rises from the Scharde Isles, fueled by necromancy and dragon blight.', image: 'https://lh3.googleusercontent.com/aida-public/AB6AXuD8gPxeQx_3lDUpLTgay69R-rsFUAxhWvk2arjev0y7gSLepW4i_fMa6tdwm_k3OXKRolFqYvIEjy7j-XKXW5-bw7NhcG_gtH_sugTk6A2lBBARWPxFHtTcUjX_P0xPSgp6Wy3_PrOEI4jmYRVcrAyBnebdqTmz9ah7STaYtMdZ-2xL0Tm7XegAQpGuq_vF6Ph2hOdFwdlhjewHG_FspJFjtN_UlGFzROopX6Txip_NVShTCTtsC84yjj00B6AFyZt4iog8rewfB4fy' },
+  { id: 2, name: 'Cygnar', code: 'CYG', type: 'Storm-Tech', icon: 'bolt', description: 'Master of lightning and sophisticated steam-tech, defending the heart of the Iron Kingdoms.', image: 'https://lh3.googleusercontent.com/aida-public/AB6AXuAaFvnT5hjY5V46Qp9-StA3eLb1aYDKiV53dgDO8Gt7tXEvaR-HlY_VaVq0CLXK5P6Ql0h6VsiYhSGeJekYHMI_kr2u9SMx_kJn889C2W8FEEKBB_6LPFruRGv2uOUBKimUmH7OPv7tCRz47UBqb9FqyyIrqHEKgficZnNTm7nBmSHnYZxeXMyGwkdx0HYkDiW9Pvk0SHF7UCtp4-Kk1h2ROyP-SYgRKZsGEgY5_kGa0BI0I8rN_7P3MXv0LsUHcyLAHZzyCA952y31' },
+  { id: 3, name: 'Khador', code: 'KHA', type: 'Heavy Armor', icon: 'shield', description: 'The Motherland\'s brute force, fielding massive warjacks that crush all in their path.', image: 'https://lh3.googleusercontent.com/aida-public/AB6AXuDj-2Iq9XzvZVZB8XVRUMZYi5ZJb35ObsNOfU_QZV2vA2D9_FvQ1Pebo8u6DmKtFitdy5TNFICAjFIQIE-azU1DcE2NKQU2Kv3CWpFBFwjA3fQBUBbW3tofjX49rebyuZS4yfbq1d1FZ5wQs6hZOpIi452bVn8zynYxv3hM8NBVUd-qBMj18GldB9IigemEWFRt0v5Une7RzDFSsrTImyChvTNNuyPJqnkx5p8OIliZ5fabxTqj6gxTjaEsgl0gjuUlI-6vfUVAlKEl' },
+  { id: 4, name: 'Protectorate', code: 'MEN', type: 'Holy Zeal', icon: 'local_fire_department', description: 'Fanatical warriors of Menoth, purging the unfaithful with cleansing fire and holy law.', image: 'https://lh3.googleusercontent.com/aida-public/AB6AXuBUAZ6TzQIAVLKLQWCWxMJsMOkq2FuWtaAWyKHDDb7FhGV0ClQT7BTi2j311vqcxYquDoy_1BKzTbBVDX37SA5RrvEdif0D2GMRUFp33JkloI5Q9Ejud0kApe-GITBwnpQm8OhTM-J9YlISg0zhAOoLczUVRv3hO-6Ka9K8lU8U5HDS62P9wR106a7kvLlmgVBIS7GfmFbvcPju1FJwY0wxGpOiZSG3bsX5q2cUm8Z9y4MbGRg4rk0HmEGSxf9V4wNJY1GTvb4asuoY' },
+  { id: 5, name: 'Convergence', code: 'COC', type: 'Clockwork Soul', icon: 'settings_gear_alt', description: 'The Great Machine seeks perfection through clockwork engineering and celestial alignment.', image: 'https://lh3.googleusercontent.com/aida-public/AB6AXuDrMXterZU_SaA-gfY5pi-j7GQ2dyoh7GRGVKiEqXd_Mx4Hzhoj7d4XTfWn_tANfqVmbo6ggpWCT18yCqQMfuzQkMSzpJRS7bNieGkDUDGXbvxiInGg1XDuI6h8obTBnxkOBa0hoXC2gLfmt9EHbfxgqYudiw9B5hBQ9BAnl-VDTwabLEFtXsUQ7QwNx-Wqoy-2YNrOwK19P_resDbwApKLgSuluP4tqlylvoyjwb8sqzOvszpK0HrMv9B5Fy_pIJt7-WnAeX8E-Grm' },
+  { id: 6, name: 'Retribution', code: 'ROS', type: 'Mage Hunter', icon: 'auto_awesome', description: 'Elven hunters determined to save their dying gods by eliminating human magic users.', image: 'https://lh3.googleusercontent.com/aida-public/AB6AXuCaCx8H2A9qClYs0t8kAq4yJciS8pZGjivgZB-9AuzVa4O0AuSC8OGYrVe1m8y2Rt_Uqta4WJxTdXxs9nzKy6GgucyGxB0dJVaGVpOl96iExiq8TtIkc6cqPQky0tNWEcvk0M6sZHhKtJqrtVSBLTm2fKdueS26tHTb29vB-DBpWGk4c_Ugi3u-hERDBu9MpEiP5ihhQs1Cl4RlxLlbBDT8FXeMMdUfCVTxzVtJhitW8b7I-cGmtHs8RXATpPb8IAXEjuZBdDPa3iVh' }
+]
+</script>
+
+<style scoped>
+.v2-factions-page {
+  padding: 0;
+}
+
+.v2-page-header {
+  margin-bottom: 48px;
+}
+
+.v2-title-main {
+  font-size: 48px;
+  font-weight: 900;
+  color: var(--v2-on-surface);
+  letter-spacing: -0.05em;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+
+.v2-text-italic {
+  color: var(--v2-primary);
+  font-style: italic;
+}
+
+.v2-header-accent {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.v2-accent-line {
+  height: 2px;
+  width: 96px;
+  background-color: var(--v2-primary);
+}
+
+.v2-header-subtitle {
+  font-size: 14px;
+  color: var(--v2-outline);
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+}
+
+.faction-info-box {
+  margin-bottom: 16px;
+}
+
+.faction-type-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+.faction-type-icon {
+  color: var(--v2-primary);
+  font-size: 14px;
+}
+
+.faction-type-label {
+  font-size: 12px;
+  color: var(--v2-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.faction-name-v2 {
+  font-size: 30px;
+  font-weight: 900;
+  letter-spacing: -0.025em;
+  text-transform: uppercase;
+}
+
+.faction-desc-v2 {
+  font-size: 14px;
+  color: var(--v2-on-surface-variant);
+  margin-bottom: 24px;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.faction-btn-v2 {
+  width: 100%;
+  font-size: 12px;
+}
+
+.faction-bento-grid {
+  display: grid;
+  grid-template-columns: repeat(1, 1fr);
+  gap: 24px;
+}
+
+@media (min-width: 768px) {
+  .faction-bento-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 1280px) {
+  .faction-bento-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.faction-card-v2 {
+  position: relative;
+  overflow: hidden;
+  background-color: var(--v2-surface-container-low);
+  border: 1px solid rgba(134, 147, 150, 0.1);
+  transition: all 0.5s ease;
+}
+
+.faction-card-v2:hover {
+  border-color: rgba(79, 215, 240, 0.5);
+}
+
+.card-gradient-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to top, var(--v2-background), transparent, transparent);
+  z-index: 10;
+}
+
+.card-bg-image {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  opacity: 0.3;
+  transition: transform 0.7s ease;
+}
+
+.faction-card-v2:hover .card-bg-image {
+  transform: scale(1.1);
+}
+
+.card-content-v2 {
+  position: relative;
+  z-index: 20;
+  padding: 24px;
+  height: 320px;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  box-sizing: border-box;
+}
+
+.card-top-right {
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding: 24px;
+}
+
+.faction-code-badge {
+  background-color: var(--v2-primary-container);
+  color: var(--v2-on-primary-container);
+  font-weight: 900;
+  padding: 12px;
+  font-size: 20px;
+  line-height: 1;
+}
+</style>

--- a/src/views/v2/tactical/GamePage.vue
+++ b/src/views/v2/tactical/GamePage.vue
@@ -1,0 +1,482 @@
+<template>
+  <div class="v2-game-page">
+    <!-- Scenario Map Header -->
+    <section class="glass-panel v2-game-scenario-header">
+      <div class="map-overlay-layer"></div>
+      <div class="v2-game-header-top">
+        <div class="v2-mini-map-box">
+          <!-- Trench Warfare Tactical Map Mock -->
+          <div class="v2-map-grid-overlay">
+            <div class="v2-map-crosshair">
+              <div class="v2-crosshair-h"></div>
+              <div class="v2-crosshair-v"></div>
+            </div>
+          </div>
+          <!-- Zones and Objectives -->
+          <div class="v2-map-objectives">
+            <div class="v2-map-zone zone-a animate-pulse">
+              <span class="font-label v2-zone-label">ZONE A</span>
+            </div>
+            <div class="v2-map-zone zone-b">
+              <span class="font-label v2-zone-label secondary">ZONE B</span>
+            </div>
+          </div>
+        </div>
+        <div class="v2-scenario-info">
+          <h2 class="font-headline v2-scenario-title">SCENARIO: TRENCH WARFARE</h2>
+          <p class="font-label v2-scenario-meta">Theater: Sector-9 / Grid 52.22N 21.01E</p>
+          <div class="scenario-stats-grid">
+            <div v-for="item in scenarioStatus" :key="item.label" class="v2-status-item-v2" :style="{ borderLeftColor: item.borderColorValue }">
+              <div class="v2-status-label">{{ item.label }}</div>
+              <div class="font-headline v2-status-value" :style="{ color: item.textColorValue }">{{ item.status }}</div>
+            </div>
+          </div>
+        </div>
+        <!-- Collapsed Log -->
+        <div class="hidden-xl-down v2-combat-log glass-panel">
+          <div class="v2-log-header">
+            <span class="material-symbols-outlined v2-log-icon">history</span>
+            <span class="font-headline v2-log-title">Combat Feed</span>
+          </div>
+          <div class="v2-log-entries">
+            <p v-for="log in logs" :key="log.msg" class="v2-log-entry">
+              <span class="v2-log-tag" :style="{ color: log.tagColor }">{{ log.tag }}:</span> {{ log.msg }}
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Two Player Main View -->
+    <div class="v2-game-grid">
+      <!-- Player 1 -->
+      <div class="v2-player-column">
+        <div class="v2-player-header border-primary">
+          <div class="v2-player-identity">
+            <span class="v2-player-number bg-primary-soft">1</span>
+            <h2 class="font-headline v2-player-name text-primary">VANGUARD-79</h2>
+          </div>
+          <span class="font-label v2-player-commander text-primary-dim">Commander: Stryker</span>
+        </div>
+        <div class="glass-panel v2-warcaster-card border-primary-dim">
+          <div class="v2-warcaster-row">
+            <div class="v2-warcaster-portrait border-primary-dim">
+              <img alt="Stryker" class="v2-img-grayscale" src="https://lh3.googleusercontent.com/aida-public/AB6AXuDfOv-9meJyEcO6-vQurAPPQxLRBzy2PsquiUUVoeolqIJcO4vm1BJsnXHC5PoischVlXHDm0pclD3Xe4RXomexU7Pml_UHysP0B2JjFbtXr3tYengsur5nUwBf4oUeCMZhyENwoo8-gRm34pEYOxpZFbi9_gUMwfpyM7ZNjIU_eqcrfV-Vail8txljEaGMjKJC0gn1KS3iWURpMRjBwtidkGFA6sqR1tyFGP4bBnCz8egg2xng7GRCk6VjRz5agvhT01L6AzAKvAtY"/>
+            </div>
+            <div class="v2-warcaster-info">
+              <div class="v2-warcaster-header">
+                <h3 class="font-headline v2-warcaster-name">Major Stryker</h3>
+                <span class="font-label v2-warcaster-status status-active">Active</span>
+              </div>
+              <div class="v2-game-stats-row">
+                <div class="v2-game-stat-box"><div class="stat-label-mini">FOC</div><div class="stat-val-mini text-tertiary">6/6</div></div>
+                <div class="v2-game-stat-box"><div class="stat-label-mini">DEF</div><div class="stat-val-mini">16</div></div>
+                <div class="v2-game-stat-box"><div class="stat-label-mini">ARM</div><div class="stat-val-mini">18</div></div>
+              </div>
+              <div class="v2-health-bar-container">
+                <div class="v2-health-bar bg-primary" :style="{ width: '85%' }"></div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="v2-jacks-row">
+          <div class="glass-panel v2-jack-mini-card border-primary-dim-soft">
+            <div class="v2-jack-mini-header">
+              <span class="font-headline v2-jack-mini-name">Ironclad</span>
+              <span class="v2-jack-mini-type">Heavy</span>
+            </div>
+            <div class="v2-damage-grid-mini">
+              <div v-for="n in 18" :key="n" class="v2-grid-cell" :class="{ filled: n <= 10, damaged: n === 11 }"></div>
+            </div>
+          </div>
+          <div class="glass-panel v2-jack-mini-card border-primary-dim-soft">
+            <div class="v2-jack-mini-header">
+              <span class="font-headline v2-jack-mini-name">Charger</span>
+              <span class="v2-jack-mini-type">Light</span>
+            </div>
+            <div class="v2-damage-grid-mini grid-4">
+              <div v-for="n in 8" :key="n" class="v2-grid-cell" :class="{ filled: n <= 7 }"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Player 2 -->
+      <div class="v2-player-column">
+        <div class="v2-player-header border-secondary">
+          <div class="v2-player-identity">
+            <span class="v2-player-number bg-secondary-soft">2</span>
+            <h2 class="font-headline v2-player-name text-secondary">IRON-CLAW</h2>
+          </div>
+          <span class="font-label v2-player-commander text-secondary-dim">Commander: Sorscha</span>
+        </div>
+        <div class="glass-panel v2-warcaster-card border-secondary-dim">
+          <div class="v2-warcaster-row">
+            <div class="v2-warcaster-portrait border-secondary-dim">
+              <img alt="Sorscha" class="v2-img-grayscale-bright" src="https://lh3.googleusercontent.com/aida-public/AB6AXuD79THejQ89wmAbJovEUjopNGKXrdx2tIA_FbsTGZWOngJ1NnlZEjR2jDEKmjBihjBCkQI3OZu2VG969ZlaILWbiODnYlC9VLLDZ_iAdGoTCisCeGgWlyNkn9GdPH5Yr5qg4EpsEzGPnAlJfJ_9nKDYvVvkG3x7mJSl7buGHmYeTE6PazES6O4TpdeXbOiBez_gIFy2XPaUAgTTaeUW1sjSlwmG3CgbzPnqd4IKNQvnX3FVLyPXhweuYFCPrgCBoOQXHMBpoA1s5Z-3"/>
+            </div>
+            <div class="v2-warcaster-info">
+              <div class="v2-warcaster-header">
+                <h3 class="font-headline v2-warcaster-name">Forward Kommander Sorscha</h3>
+                <span class="font-label v2-warcaster-status status-standby">Standby</span>
+              </div>
+              <div class="v2-game-stats-row">
+                <div class="v2-game-stat-box"><div class="stat-label-mini">FOC</div><div class="stat-val-mini text-secondary">4/6</div></div>
+                <div class="v2-game-stat-box"><div class="stat-label-mini">DEF</div><div class="stat-val-mini">15</div></div>
+                <div class="v2-game-stat-box"><div class="stat-label-mini">ARM</div><div class="stat-val-mini">17</div></div>
+              </div>
+              <div class="v2-health-bar-container">
+                <div class="v2-health-bar bg-secondary" :style="{ width: '100%' }"></div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="v2-jacks-row">
+          <div class="glass-panel v2-jack-mini-card border-secondary-dim-soft">
+            <div class="v2-jack-mini-header">
+              <span class="font-headline v2-jack-mini-name">Juggernaut</span>
+              <span class="v2-jack-mini-type">Heavy</span>
+            </div>
+            <div class="v2-damage-grid-mini">
+              <div v-for="n in 18" :key="n" class="v2-grid-cell filled opponent-filled"></div>
+            </div>
+          </div>
+          <div class="glass-panel v2-jack-mini-card border-secondary-dim-soft opacity-50">
+            <div class="v2-jack-mini-header">
+              <span class="font-headline v2-jack-mini-name text-error">Destroyer</span>
+              <span class="v2-jack-mini-type text-error">Destroyed</span>
+            </div>
+            <div class="v2-damage-grid-mini opacity-30">
+              <div v-for="n in 6" :key="n" class="v2-grid-cell damaged"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+const scenarioStatus = [
+  { label: 'Zone A', status: 'Contested', borderColorValue: '#4fd7f0', textColorValue: '#4fd7f0' },
+  { label: 'Zone B', status: 'Enemy Controlled', borderColorValue: '#ffb68b', textColorValue: '#ffb68b' },
+  { label: 'Objective 1', status: 'Secured', borderColorValue: '#00daf3', textColorValue: '#00daf3' },
+  { label: 'Objective 2', status: 'Destroyed', borderColorValue: '#ffb4ab', textColorValue: '#ffb4ab' }
+]
+
+const logs = [
+  { tag: 'V-79', msg: 'Stryker cast Arcane Shield.', tagColor: '#4fd7f0' },
+  { tag: 'I-CLAW', msg: 'Ironclad sustains 4 DMG.', tagColor: '#ffb68b' },
+  { tag: 'ALERT', msg: 'Objective 2 down.', tagColor: '#ffb4ab' }
+]
+</script>
+
+<style scoped>
+.v2-game-page {
+  padding-bottom: 48px;
+}
+
+.v2-game-scenario-header {
+  margin-bottom: 32px;
+  border: 1px solid rgba(134, 147, 150, 0.2);
+  padding: 16px;
+  position: relative;
+  overflow: hidden;
+  box-sizing: border-box;
+}
+
+.v2-game-header-top {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  align-items: center;
+}
+
+@media (min-width: 768px) {
+  .v2-game-header-top {
+    flex-direction: row;
+  }
+}
+
+.v2-mini-map-box {
+  flex-shrink: 0;
+  width: 256px;
+  height: 160px;
+  background-color: var(--v2-surface-container-lowest);
+  border: 1px solid rgba(79, 215, 240, 0.3);
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.v2-map-grid-overlay {
+  position: absolute;
+  inset: 0;
+  opacity: 0.2;
+  border: 1px solid rgba(79, 215, 240, 0.1);
+}
+
+.v2-map-crosshair {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.v2-crosshair-h { width: 100%; height: 1px; background-color: rgba(79, 215, 240, 0.2); }
+.v2-crosshair-v { height: 100%; width: 1px; background-color: rgba(79, 215, 240, 0.2); }
+
+.v2-map-objectives {
+  position: relative;
+  z-index: 10;
+  width: 100%;
+  height: 100%;
+  padding: 16px;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  grid-template-rows: repeat(3, 1fr);
+  gap: 8px;
+  box-sizing: border-box;
+}
+
+.v2-map-zone {
+  grid-row-start: 2;
+  width: 48px;
+  height: 48px;
+  border: 2px dashed rgba(79, 215, 240, 0.6);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.zone-a { grid-column-start: 2; border-color: rgba(79, 215, 240, 0.6); }
+.zone-b { grid-column-start: 3; border-color: rgba(255, 182, 139, 0.6); }
+
+.v2-zone-label { font-size: 6px; color: var(--v2-primary); }
+.v2-zone-label.secondary { color: var(--v2-secondary); }
+
+.v2-scenario-info {
+  flex-grow: 1;
+}
+
+.v2-scenario-title {
+  font-size: 20px;
+  font-weight: 900;
+  color: var(--v2-primary);
+  letter-spacing: -0.05em;
+  margin-bottom: 4px;
+  text-transform: uppercase;
+  font-style: italic;
+}
+
+.v2-scenario-meta {
+  font-size: 10px;
+  color: var(--v2-outline);
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  margin-bottom: 16px;
+}
+
+.scenario-stats-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 16px;
+}
+
+@media (min-width: 768px) {
+  .scenario-stats-grid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+.v2-status-item-v2 {
+  background-color: var(--v2-surface-container-high);
+  padding: 8px;
+  border-left-width: 2px;
+  border-left-style: solid;
+}
+
+.v2-status-label { font-size: 8px; color: var(--v2-outline); text-transform: uppercase; }
+.v2-status-value { font-size: 12px; font-weight: 700; text-transform: uppercase; }
+
+.v2-combat-log {
+  width: 256px;
+  border: 1px solid rgba(60, 73, 76, 0.3);
+  padding: 12px;
+  height: 160px;
+  overflow-y: auto;
+  box-sizing: border-box;
+}
+
+@media (max-width: 1279px) {
+  .hidden-xl-down { display: none !important; }
+}
+
+.v2-log-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+  padding-bottom: 4px;
+  border-bottom: 1px solid rgba(60, 73, 76, 0.3);
+}
+
+.v2-log-icon { color: var(--v2-primary); font-size: 14px; }
+.v2-log-title { font-size: 9px; font-weight: 700; color: var(--v2-on-surface); text-transform: uppercase; letter-spacing: 0.1em; }
+
+.v2-log-entries { display: flex; flex-direction: column; gap: 8px; }
+.v2-log-entry { font-size: 9px; color: var(--v2-on-surface-variant); line-height: 1.2; }
+.v2-log-tag { font-weight: 700; }
+
+.v2-game-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 32px;
+}
+
+@media (min-width: 1024px) {
+  .v2-game-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.v2-player-column { display: flex; flex-direction: column; gap: 24px; }
+
+.v2-player-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom-width: 2px;
+  border-bottom-style: solid;
+  padding-bottom: 8px;
+}
+
+.v2-player-header.border-primary { border-bottom-color: var(--v2-primary); }
+.v2-player-header.border-secondary { border-bottom-color: var(--v2-secondary); }
+
+.v2-player-identity { display: flex; align-items: center; gap: 12px; }
+
+.v2-player-number {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid currentColor;
+  font-weight: 900;
+}
+
+.bg-primary-soft { background-color: rgba(79, 215, 240, 0.2); border-color: var(--v2-primary); color: var(--v2-primary); }
+.bg-secondary-soft { background-color: rgba(255, 182, 139, 0.2); border-color: var(--v2-secondary); color: var(--v2-secondary); }
+
+.v2-player-name {
+  font-size: 20px;
+  font-weight: 900;
+  letter-spacing: -0.05em;
+  text-transform: uppercase;
+  font-style: italic;
+}
+
+.text-primary { color: var(--v2-primary); }
+.text-secondary { color: var(--v2-secondary); }
+
+.v2-player-commander { font-size: 10px; text-transform: uppercase; }
+.text-primary-dim { color: rgba(79, 215, 240, 0.6); }
+.text-secondary-dim { color: rgba(255, 182, 139, 0.6); }
+
+.v2-warcaster-card {
+  padding: 16px;
+  border-top-width: 1px;
+  border-top-style: solid;
+}
+
+.border-primary-dim { border-top-color: rgba(79, 215, 240, 0.3); }
+.border-secondary-dim { border-top-color: rgba(255, 182, 139, 0.3); }
+
+.v2-warcaster-row { display: flex; gap: 16px; }
+
+.v2-warcaster-portrait {
+  width: 64px;
+  height: 64px;
+  background-color: var(--v2-surface-container-high);
+  border-width: 1px;
+  border-style: solid;
+}
+
+.v2-warcaster-portrait.border-primary-dim { border-color: rgba(79, 215, 240, 0.3); }
+.v2-warcaster-portrait.border-secondary-dim { border-color: rgba(255, 182, 139, 0.3); }
+
+.v2-img-grayscale { width: 100%; height: 100%; object-fit: cover; filter: grayscale(1); }
+.v2-img-grayscale-bright { width: 100%; height: 100%; object-fit: cover; filter: grayscale(1) brightness(1.25); }
+
+.v2-warcaster-info { flex-grow: 1; }
+
+.v2-warcaster-header { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 4px; }
+
+.v2-warcaster-name { font-weight: 700; color: var(--v2-on-surface); text-transform: uppercase; font-size: 14px; }
+
+.v2-warcaster-status { font-size: 8px; padding: 0 4px; border-width: 1px; border-style: solid; text-transform: uppercase; }
+.status-active { color: var(--v2-tertiary); border-color: rgba(0, 218, 243, 0.3); }
+.status-standby { color: var(--v2-outline); border-color: rgba(134, 147, 150, 0.3); }
+
+.v2-game-stats-row { display: grid; grid-template-columns: repeat(3, 1fr); gap: 4px; margin-bottom: 8px; }
+
+.v2-game-stat-box {
+  background-color: var(--v2-surface-container-lowest);
+  padding: 4px 8px;
+  box-sizing: border-box;
+}
+
+.stat-label-mini { font-size: 7px; color: var(--v2-outline); text-transform: uppercase; }
+.stat-val-mini { font-size: 10px; font-weight: 700; color: white; }
+.text-tertiary { color: var(--v2-tertiary) !important; }
+
+.v2-health-bar-container { width: 100%; height: 4px; background-color: var(--v2-surface-container-highest); }
+.v2-health-bar { height: 100%; }
+.bg-primary { background-color: var(--v2-primary); }
+.bg-secondary { background-color: var(--v2-secondary); }
+
+.v2-jacks-row {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 16px;
+}
+
+@media (min-width: 768px) {
+  .v2-jacks-row {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.v2-jack-mini-card {
+  padding: 16px;
+  border-top-width: 1px;
+  border-top-style: solid;
+}
+
+.border-primary-dim-soft { border-top-color: rgba(79, 215, 240, 0.2); }
+.border-secondary-dim-soft { border-top-color: rgba(255, 182, 139, 0.2); }
+
+.v2-jack-mini-header { display: flex; justify-content: space-between; margin-bottom: 8px; }
+
+.v2-jack-mini-name { font-size: 10px; font-weight: 700; color: var(--v2-on-surface); text-transform: uppercase; }
+.v2-jack-mini-type { font-size: 8px; color: var(--v2-outline); text-transform: uppercase; }
+
+.v2-damage-grid-mini {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 2px;
+  border: 1px solid rgba(60, 73, 76, 0.3);
+  padding: 4px;
+  background-color: var(--v2-surface-container-lowest);
+}
+
+.grid-4 { grid-template-columns: repeat(4, 1fr); }
+
+.text-error { color: var(--v2-error) !important; }
+.opacity-50 { opacity: 0.5; }
+.opacity-30 { opacity: 0.3; }
+</style>

--- a/src/views/v2/tactical/SummaryPage.vue
+++ b/src/views/v2/tactical/SummaryPage.vue
@@ -1,0 +1,683 @@
+<template>
+  <div class="v2-summary-page">
+    <!-- Header Section -->
+    <div class="v2-summary-header">
+      <div>
+        <h1 class="font-headline v2-summary-title">Battalion Summary</h1>
+        <p class="font-label v2-summary-subtitle">Force Designation: VANGUARD-79 // Point Total: 1,985/2,000</p>
+      </div>
+      <div class="v2-summary-actions">
+        <button class="v2-action-btn">
+          <span class="material-symbols-outlined v2-action-icon">content_copy</span> Copy to Clipboard
+        </button>
+        <button class="v2-action-btn">
+          <span class="material-symbols-outlined v2-action-icon">picture_as_pdf</span> Export PDF
+        </button>
+        <button class="v2-share-btn">
+          <span class="material-symbols-outlined v2-share-icon">share</span> Share Link
+        </button>
+      </div>
+    </div>
+
+    <!-- Army Bento Grid -->
+    <div class="v2-summary-grid">
+      <!-- Command Structure -->
+      <div class="summary-col-main v2-card-flat v2-command-card">
+        <div class="v2-card-tag">Core Command</div>
+        <h2 class="font-headline v2-card-title">
+          <span class="material-symbols-outlined">stars</span> Command Structure
+        </h2>
+        <div class="v2-unit-stack">
+          <!-- Unit Entry -->
+          <div v-for="commander in commandStructure" :key="commander.name" class="v2-unit-entry-v2">
+            <div>
+              <h3 class="font-headline v2-commander-name">{{ commander.name }}</h3>
+              <p class="v2-commander-role">{{ commander.role }}</p>
+              <div v-if="commander.traits" class="v2-traits-row">
+                <span v-for="trait in commander.traits" :key="trait.name" class="v2-mini-tag" :style="{ color: trait.colorValue || '#ffb68b' }">{{ trait.name }}</span>
+              </div>
+            </div>
+            <div class="v2-commander-pts">
+              <div class="font-headline v2-pts-val">{{ commander.points }}</div>
+              <div class="font-label v2-pts-label">PTS</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Detachment Rules -->
+      <div class="summary-col-side v2-card-flat v2-detachment-card">
+        <h2 class="font-headline v2-detachment-title">
+          <span class="material-symbols-outlined">bolt</span> Force Traits
+        </h2>
+        <ul class="v2-traits-list">
+          <li v-for="trait in forceTraits" :key="trait.name">
+            <div class="font-label v2-trait-name">{{ trait.name }}</div>
+            <p class="v2-trait-desc">{{ trait.description }}</p>
+          </li>
+        </ul>
+      </div>
+
+      <!-- Main Battle Line -->
+      <div class="summary-col-full v2-card-flat v2-battle-line-card">
+        <h2 class="font-headline v2-battle-line-title">
+          <span class="material-symbols-outlined">group</span> Battle Line Units
+        </h2>
+        <div class="battle-line-grid">
+          <div v-for="unit in battleLine" :key="unit.name" class="v2-summary-unit-card">
+            <div class="v2-unit-card-header">
+              <h4 class="font-headline v2-unit-card-name">{{ unit.name }}</h4>
+              <span class="font-headline v2-unit-card-pts">{{ unit.points }} PTS</span>
+            </div>
+            <p class="v2-unit-card-equip">Equipment: {{ unit.equipment }}</p>
+            <div class="unit-stat-bar-v2">
+              <div v-for="(val, stat) in unit.stats" :key="stat">
+                <div class="font-label v2-unit-stat-label">{{ stat }}</div>
+                <div class="v2-unit-stat-val">{{ val }}</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Heavy Support & Armor -->
+      <div class="summary-col-l-7 v2-card-flat v2-heavy-support-card">
+        <h2 class="font-headline v2-heavy-support-title">
+          <span class="material-symbols-outlined">rocket_launch</span> Heavy Support
+        </h2>
+        <div class="v2-heavy-stack">
+          <div v-for="support in heavySupport" :key="support.name" class="v2-heavy-item-v2 group">
+            <img class="v2-heavy-img" :src="support.image"/>
+            <div class="v2-heavy-info">
+              <div class="v2-heavy-header">
+                <h3 class="font-headline v2-heavy-name">{{ support.name }}</h3>
+                <span class="font-headline v2-heavy-pts">{{ support.points }} PTS</span>
+              </div>
+              <p class="v2-heavy-desc">{{ support.description }}</p>
+              <div class="v2-heavy-integrity">
+                <div class="v2-integrity-bg">
+                  <div class="v2-integrity-bar" :style="{ width: support.integrity + '%' }"></div>
+                </div>
+                <span class="font-label v2-integrity-text">{{ support.statusText }}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Strategic Summary / Notes -->
+      <div class="summary-col-l-5 v2-card-flat v2-strategic-card">
+        <h2 class="font-headline v2-strategic-title">
+          <span class="material-symbols-outlined">analytics</span> Strategic Assets
+        </h2>
+        <div class="v2-strategic-stack">
+          <div class="v2-cp-box">
+            <div class="font-label v2-cp-label">Command Points (CP)</div>
+            <div class="font-headline v2-cp-val">12 <span class="v2-cp-meta">STARTING</span></div>
+          </div>
+          <div class="v2-memo-box">
+            <h4 class="font-label v2-memo-title">Tactical Memo</h4>
+            <p class="v2-memo-text">"Focus fire on enemy heavy transport in turn 1. Use Storm-Strider to anchor the left flank while scouts screen for deep strikes. Conserve CP for 'Overcharged Void Shields' in late game."</p>
+          </div>
+          <div class="v2-strategic-stats">
+            <div class="v2-strat-stat-item">
+              <div class="v2-strat-stat-label">Unit Count</div>
+              <div class="font-headline v2-strat-stat-val">14</div>
+            </div>
+            <div class="v2-strat-stat-item">
+              <div class="v2-strat-stat-label">Model Count</div>
+              <div class="font-headline v2-strat-stat-val">58</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+const commandStructure = [
+  { name: 'Arch-Commander Malacor', role: 'Leader, Master of the Void, Tactical Analyst', points: 245, traits: [{ name: 'Relic: Obsidian Plate', colorValue: '#ffb68b' }, { name: 'Trait: Inspiring Focus', colorValue: '#00daf3' }] },
+  { name: 'Shield-Captain Vane', role: 'Second-in-Command, Frontline Specialist', points: 180 }
+]
+
+const forceTraits = [
+  { name: 'Relentless Advance', description: 'Infantry units ignore movement penalties when shooting heavy weapons.' },
+  { name: 'Neural Linkage', description: '+1 to hit rolls for units within 6" of a COMMAND unit.' },
+  { name: 'Void Shielding', description: 'First wound dealt each turn to a Vehicle is ignored.' }
+]
+
+const battleLine = [
+  { name: 'Ironclad Vanguard (x10)', points: 150, equipment: 'Plasma Rifles, Power Blades', stats: { SPD: '6"', STR: 4, MAT: '3+', WND: 2 } },
+  { name: 'Ironclad Vanguard (x10)', points: 150, equipment: 'Plasma Rifles, Power Blades', stats: { SPD: '6"', STR: 4, MAT: '3+', WND: 2 } },
+  { name: 'Pathfinder Scouts (x5)', points: 90, equipment: 'Rail Snipers, Camo Cloaks', stats: { SPD: '8"', STR: 3, MAT: '4+', WND: 1 } }
+]
+
+const heavySupport = [
+  { name: 'Storm-Strider Walker', points: 420, description: 'Heavy Armor // Multi-Launcher // Void Array', integrity: 85, statusText: 'STRUCTURAL INTEGRITY: 85%', image: 'https://lh3.googleusercontent.com/aida-public/AB6AXuDKObaej7aiBHPGRmdqNgOVdEUWcwCQ13atiHIJ1fkSxzxuZC-lU5C5kokTq47UfHexowSppfzNJWP8CvGOOL0Yv9Mt7ksTeF6ridjfbrrGrvFMOU65za3Xabzv9MkYXRIKvdAdoXSR9wgFznlPP8dfH-vguJRAzdSrGkUFl7SIjM6h5GiIFl4dTkrL1bmTSqO_31Q-163qZ3iOq9N6EeOYGvUlZkxEdPGt7r8c47ac9kpAtMPlw421MKUMwrm8Eh1rRriCjHhbjdaI' },
+  { name: 'Hellstorm Battery', points: 310, description: 'Artillery // Incendiary Rounds', integrity: 100, statusText: 'READY FOR DEPLOYMENT', image: 'https://lh3.googleusercontent.com/aida-public/AB6AXuA3OBmPFnVgP-UtypMGj2lnC7uHcS_24cosymuSrIJqFfG6aEkx0vYni_AjblZdRPWvTvND_nmhwrpccdUJh899X0AKQcPEb4Bl_iM7yGHYffeX11EbdMpAUeWbW6QKxy7kFbNAN1nDG-ivIPZ05zL62JVY3jT0FtdG-wOYlnOVd9E-NNmC5JK4Zpv6jMrC5PJOo1bR86rlxqo9chFuCwN2VSnqm6b7Q6bGURahds5CtUOyScg-uR2IMRb-mjc1PCSe9vk9TlkXnneb' }
+]
+</script>
+
+<style scoped>
+.v2-summary-page {
+  max-width: 1152px;
+  margin: 0 auto;
+  padding-bottom: 48px;
+}
+
+.v2-summary-header {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 32px;
+  border-left: 4px solid var(--v2-primary);
+  padding-left: 24px;
+  padding-top: 8px;
+  padding-bottom: 8px;
+}
+
+@media (min-width: 768px) {
+  .v2-summary-header {
+    flex-direction: row;
+    align-items: flex-end;
+  }
+}
+
+.v2-summary-title {
+  font-size: 36px;
+  font-weight: 900;
+  letter-spacing: -0.05em;
+  color: var(--v2-on-surface);
+  margin-bottom: 8px;
+  text-transform: uppercase;
+}
+
+.v2-summary-subtitle {
+  color: var(--v2-primary-container);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  font-size: 14px;
+}
+
+.v2-summary-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.v2-action-btn {
+  background-color: var(--v2-surface-container-high);
+  color: var(--v2-primary);
+  border-top: 1px solid rgba(79, 215, 240, 0.3);
+  padding: 8px 20px;
+  font-family: var(--v2-font-label);
+  font-weight: 700;
+  text-transform: uppercase;
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  border-left: none; border-right: none; border-bottom: none;
+  transition: background-color 0.3s ease;
+}
+
+.v2-action-btn:hover {
+  background-color: var(--v2-surface-container-highest);
+}
+
+.v2-action-icon {
+  font-size: 18px;
+}
+
+.v2-share-btn {
+  background: linear-gradient(to right, var(--v2-primary), var(--v2-primary-container));
+  color: var(--v2-on-primary);
+  padding: 8px 20px;
+  font-family: var(--v2-font-label);
+  font-weight: 700;
+  text-transform: uppercase;
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  border: none;
+  box-shadow: 0 0 15px rgba(79, 215, 240, 0.3);
+}
+
+.v2-share-icon {
+  font-size: 18px;
+  font-variation-settings: 'FILL' 1;
+}
+
+.v2-summary-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 4px;
+}
+
+@media (min-width: 768px) {
+  .v2-summary-grid {
+    grid-template-columns: repeat(12, 1fr);
+  }
+  .summary-col-main { grid-column: span 8; }
+  .summary-col-side { grid-column: span 4; }
+  .summary-col-full { grid-column: span 12; }
+  .summary-col-l-7 { grid-column: span 12; }
+  .summary-col-l-5 { grid-column: span 12; }
+}
+
+@media (min-width: 1024px) {
+  .summary-col-l-7 { grid-column: span 7; }
+  .summary-col-l-5 { grid-column: span 5; }
+}
+
+.v2-card-flat {
+  background-color: var(--v2-surface-container-low);
+  position: relative;
+  box-sizing: border-box;
+}
+
+.v2-command-card {
+  border-top: 1px solid rgba(79, 215, 240, 0.2);
+  padding: 24px;
+}
+
+.v2-card-tag {
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding: 12px;
+  background-color: rgba(0, 178, 202, 0.1);
+  font-family: var(--v2-font-label);
+  font-size: 10px;
+  color: var(--v2-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.v2-card-title {
+  font-size: 24px;
+  font-weight: 900;
+  color: var(--v2-primary);
+  margin-bottom: 24px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  text-transform: uppercase;
+}
+
+.v2-unit-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.v2-unit-entry-v2 {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  border-bottom: 1px solid rgba(60, 73, 76, 0.3);
+  padding-bottom: 16px;
+}
+
+.v2-commander-name {
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--v2-on-surface);
+}
+
+.v2-commander-role {
+  font-size: 14px;
+  color: #94a3b8;
+  font-style: italic;
+}
+
+.v2-traits-row {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.v2-mini-tag {
+  background-color: var(--v2-surface-container-highest);
+  padding: 2px 8px;
+  font-family: var(--v2-font-label);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: -0.05em;
+}
+
+.v2-commander-pts {
+  text-align: right;
+}
+
+.v2-pts-val {
+  font-size: 20px;
+  font-weight: 900;
+  color: var(--v2-primary);
+}
+
+.v2-pts-label {
+  font-size: 10px;
+  color: #64748b;
+  text-transform: uppercase;
+}
+
+.v2-detachment-card {
+  background-color: var(--v2-surface-container);
+  border-top: 1px solid rgba(255, 127, 28, 0.2);
+  padding: 24px;
+}
+
+.v2-detachment-title {
+  font-size: 20px;
+  font-weight: 900;
+  color: var(--v2-secondary);
+  margin-bottom: 16px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  text-transform: uppercase;
+}
+
+.v2-traits-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 0;
+  list-style: none;
+}
+
+.v2-trait-name {
+  font-weight: 700;
+  color: var(--v2-on-surface);
+  font-size: 14px;
+  text-transform: uppercase;
+}
+
+.v2-trait-desc {
+  font-size: 12px;
+  color: #94a3b8;
+  margin-top: 4px;
+}
+
+.v2-battle-line-card {
+  border-top: 1px solid rgba(79, 215, 240, 0.2);
+  padding: 24px;
+}
+
+.v2-battle-line-title {
+  font-size: 24px;
+  font-weight: 900;
+  color: var(--v2-primary);
+  margin-bottom: 24px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  text-transform: uppercase;
+}
+
+.battle-line-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 24px;
+}
+
+@media (min-width: 768px) {
+  .battle-line-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 1024px) {
+  .battle-line-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.v2-summary-unit-card {
+  background-color: var(--v2-surface-container);
+  padding: 16px;
+  border-left: 2px solid rgba(79, 215, 240, 0.4);
+}
+
+.v2-unit-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 8px;
+}
+
+.v2-unit-card-name {
+  font-weight: 700;
+  color: var(--v2-on-surface);
+  text-transform: uppercase;
+}
+
+.v2-unit-card-pts {
+  font-weight: 900;
+  color: var(--v2-primary);
+  font-size: 14px;
+}
+
+.v2-unit-card-equip {
+  font-size: 11px;
+  color: #64748b;
+  text-transform: uppercase;
+  margin-bottom: 12px;
+}
+
+.unit-stat-bar-v2 {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+  text-align: center;
+  background-color: var(--v2-surface-container-lowest);
+  padding: 8px 0;
+}
+
+.v2-unit-stat-label {
+  font-size: 9px;
+  color: #64748b;
+  text-transform: uppercase;
+}
+
+.v2-unit-stat-val {
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.v2-heavy-support-card {
+  border-top: 1px solid rgba(79, 215, 240, 0.2);
+  padding: 24px;
+}
+
+.v2-heavy-support-title {
+  font-size: 24px;
+  font-weight: 900;
+  color: var(--v2-primary);
+  margin-bottom: 24px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  text-transform: uppercase;
+}
+
+.v2-heavy-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.v2-heavy-item-v2 {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  padding: 16px;
+  background-color: var(--v2-surface-container);
+  transition: background-color 0.3s ease;
+}
+
+.v2-heavy-item-v2:hover {
+  background-color: var(--v2-surface-container-high);
+}
+
+.v2-heavy-img {
+  width: 96px;
+  height: 96px;
+  object-fit: cover;
+  border: 1px solid rgba(79, 215, 240, 0.3);
+}
+
+.v2-heavy-info {
+  flex: 1;
+}
+
+.v2-heavy-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
+.v2-heavy-name {
+  font-weight: 700;
+  color: var(--v2-on-surface);
+  font-size: 20px;
+}
+
+.v2-heavy-pts {
+  font-weight: 900;
+  color: var(--v2-primary);
+}
+
+.v2-heavy-desc {
+  font-size: 12px;
+  color: #94a3b8;
+  margin-top: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.v2-heavy-integrity {
+  margin-top: 12px;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.v2-integrity-bg {
+  height: 4px;
+  flex: 1;
+  background-color: var(--v2-surface-container-highest);
+  overflow: hidden;
+}
+
+.v2-integrity-bar {
+  height: 100%;
+  background-color: var(--v2-primary);
+  box-shadow: 0 0 8px rgba(79, 215, 240, 0.5);
+}
+
+.v2-integrity-text {
+  font-size: 10px;
+  color: var(--v2-primary);
+  line-height: 1;
+}
+
+.v2-strategic-card {
+  background-color: var(--v2-surface-container);
+  border-top: 1px solid rgba(0, 178, 202, 0.2);
+  padding: 24px;
+}
+
+.v2-strategic-title {
+  font-size: 20px;
+  font-weight: 900;
+  color: var(--v2-tertiary);
+  margin-bottom: 16px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  text-transform: uppercase;
+}
+
+.v2-strategic-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.v2-cp-box {
+  background-color: var(--v2-surface-container-low);
+  padding: 16px;
+  position: relative;
+}
+
+.v2-cp-label {
+  font-size: 10px;
+  font-weight: 700;
+  color: #64748b;
+  text-transform: uppercase;
+  margin-bottom: 4px;
+}
+
+.v2-cp-val {
+  font-size: 30px;
+  font-weight: 900;
+  color: var(--v2-on-surface);
+}
+
+.v2-cp-meta {
+  font-size: 14px;
+  font-weight: 400;
+  color: #64748b;
+}
+
+.v2-memo-box {
+  padding: 16px;
+  border: 1px solid rgba(60, 73, 76, 0.2);
+}
+
+.v2-memo-title {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--v2-primary);
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+
+.v2-memo-text {
+  font-size: 14px;
+  color: #cbd5e1;
+  font-style: italic;
+  line-height: 1.625;
+}
+
+.v2-strategic-stats {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+.v2-strat-stat-item {
+  background-color: var(--v2-surface-container-highest);
+  padding: 12px;
+  text-align: center;
+}
+
+.v2-strat-stat-label {
+  font-size: 9px;
+  color: #94a3b8;
+  text-transform: uppercase;
+}
+
+.v2-strat-stat-val {
+  font-size: 20px;
+  font-weight: 700;
+}
+</style>

--- a/src/views/v2/tactical/TacticalLayout.vue
+++ b/src/views/v2/tactical/TacticalLayout.vue
@@ -1,0 +1,383 @@
+<template>
+  <div class="v2-theme v2-tactical-layout">
+    <!-- TopNavBar Implementation -->
+    <header class="v2-header tonal-shift-glass v2-tactical-header">
+      <div class="v2-header-logo-box">
+        <span class="font-headline v2-tactical-logo">TACTICAL COMMAND</span>
+      </div>
+      <div class="hidden-md-down v2-header-nav">
+        <router-link to="/v2/tactical/factions" class="font-headline v2-nav-link" active-class="active">Factions</router-link>
+        <router-link to="/v2/tactical/builder" class="font-headline v2-nav-link" active-class="active">Active Army</router-link>
+        <router-link to="/v2/tactical/unit" class="font-headline v2-nav-link" active-class="active">Unit Intel</router-link>
+      </div>
+      <div class="v2-header-actions">
+        <div class="v2-search-box">
+          <span class="material-symbols-outlined v2-search-icon">search</span>
+          <input class="font-label v2-search-input" placeholder="FILTER ENCRYPTED FEED..." type="text"/>
+        </div>
+        <span class="material-symbols-outlined v2-action-icon">notifications_active</span>
+        <span class="material-symbols-outlined v2-action-icon">settings</span>
+      </div>
+    </header>
+
+    <!-- SideNavBar Implementation -->
+    <aside class="v2-aside hidden-lg-down v2-tactical-aside">
+      <div class="v2-aside-profile">
+        <div class="v2-profile-box">
+          <div class="v2-profile-avatar">
+            <span class="material-symbols-outlined v2-avatar-icon">account_circle</span>
+          </div>
+          <div>
+            <div class="font-headline v2-profile-name">STRATOS-01</div>
+            <div class="v2-profile-rank">Field Commander</div>
+          </div>
+        </div>
+      </div>
+      <nav class="v2-aside-nav">
+        <router-link to="/v2/tactical/factions" class="v2-side-link" active-class="active">
+          <span class="material-symbols-outlined">shield</span>
+          <span class="font-headline">Factions</span>
+        </router-link>
+        <router-link to="/v2/tactical/builder" class="v2-side-link" active-class="active">
+          <span class="material-symbols-outlined">military_tech</span>
+          <span class="font-headline">Active Army</span>
+        </router-link>
+        <router-link to="/v2/tactical/unit" class="v2-side-link" active-class="active">
+          <span class="material-symbols-outlined">biotech</span>
+          <span class="font-headline">Unit Intel</span>
+        </router-link>
+        <a class="v2-side-link" href="#">
+          <span class="material-symbols-outlined">inventory_2</span>
+          <span class="font-headline">Archive</span>
+        </a>
+      </nav>
+      <button class="v2-button v2-button-primary v2-aside-btn">
+        <span class="material-symbols-outlined">add_box</span>
+        NEW ARMY
+      </button>
+    </aside>
+
+    <!-- Main Content Canvas -->
+    <main class="v2-main tactical-main-bg v2-tactical-main">
+      <div class="content-container">
+        <router-view />
+      </div>
+    </main>
+
+    <!-- BottomNavBar Implementation -->
+    <nav class="v2-bottom-nav lg-hidden v2-tactical-bottom-nav">
+      <router-link to="/v2/tactical/factions" class="v2-bottom-link" active-class="active">
+        <span class="material-symbols-outlined">hub</span>
+        <span class="font-body v2-bottom-label">HQ</span>
+      </router-link>
+      <router-link to="/v2/tactical/builder" class="v2-bottom-link" active-class="active">
+        <span class="material-symbols-outlined">grid_view</span>
+        <span class="font-body v2-bottom-label">Barracks</span>
+      </router-link>
+      <router-link to="/v2/tactical/unit" class="v2-bottom-link" active-class="active">
+        <span class="material-symbols-outlined">analytics</span>
+        <span class="font-body v2-bottom-label">Intel</span>
+      </router-link>
+      <router-link to="/v2/tactical/summary" class="v2-bottom-link" active-class="active">
+        <span class="material-symbols-outlined">format_list_bulleted</span>
+        <span class="font-body v2-bottom-label">Summary</span>
+      </router-link>
+    </nav>
+
+    <!-- FAB for Quick Creation (Mobile Only) -->
+    <button class="v2-fab md-hidden v2-tactical-fab">
+      <span class="material-symbols-outlined">add</span>
+    </button>
+  </div>
+</template>
+
+<style>
+@import '@/style.v2.css';
+@import '@/wardice.app.v2.css';
+</style>
+
+<style scoped>
+.v2-tactical-layout {
+  display: flex;
+  flex-direction: column;
+}
+
+.v2-tactical-header {
+  border-bottom: 1px solid rgba(8, 71, 93, 0.3);
+  background-color: rgba(2, 6, 23, 0.8);
+  backdrop-filter: blur(16px);
+  box-shadow: 0 0 15px rgba(79, 215, 240, 0.1);
+}
+
+.v2-header-logo-box {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.v2-tactical-logo {
+  color: var(--v2-primary);
+  font-weight: 900;
+  letter-spacing: -0.05em;
+  font-style: italic;
+  font-size: 20px;
+  text-transform: uppercase;
+}
+
+.v2-header-nav {
+  display: flex;
+  gap: 32px;
+  align-items: center;
+  height: 100%;
+}
+
+.v2-nav-link {
+  color: #64748b;
+  text-decoration: none;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  font-size: 14px;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  padding: 0 8px;
+  transition: all 0.3s ease;
+}
+
+.v2-nav-link:hover {
+  color: #5eead4;
+  background-color: rgba(21, 94, 117, 0.2);
+}
+
+.v2-nav-link.active {
+  color: var(--v2-primary);
+  border-bottom: 2px solid var(--v2-primary);
+}
+
+.v2-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  color: var(--v2-primary);
+}
+
+.v2-search-box {
+  position: relative;
+  display: flex;
+  align-items: center;
+  background-color: var(--v2-surface-container-lowest);
+  border-bottom: 1px solid var(--v2-outline-variant);
+  padding: 4px 12px;
+}
+
+.v2-search-icon {
+  font-size: 14px;
+  margin-right: 8px;
+}
+
+.v2-search-input {
+  background: transparent;
+  border: none;
+  color: white;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: -0.05em;
+  width: 128px;
+  padding: 0;
+}
+
+.v2-action-icon {
+  cursor: pointer;
+}
+
+.v2-tactical-aside {
+  border-right: 1px solid rgba(8, 71, 93, 0.2);
+  background-color: rgba(15, 23, 42, 0.95);
+  backdrop-filter: blur(24px);
+}
+
+.v2-aside-profile {
+  margin-bottom: 40px;
+  padding: 0 16px;
+}
+
+.v2-profile-box {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.v2-profile-avatar {
+  width: 40px;
+  height: 40px;
+  background-color: var(--v2-surface-container-highest);
+  border: 1px solid rgba(79, 215, 240, 0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.v2-avatar-icon {
+  color: var(--v2-primary);
+  font-variation-settings: 'FILL' 1;
+}
+
+.v2-profile-name {
+  color: var(--v2-tertiary);
+  font-weight: 800;
+  font-size: 14px;
+  letter-spacing: -0.025em;
+}
+
+.v2-profile-rank {
+  color: #94a3b8;
+  font-size: 10px;
+  text-transform: uppercase;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+}
+
+.v2-aside-nav {
+  flex-grow: 1;
+}
+
+.v2-side-link {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  color: #94a3b8;
+  text-decoration: none;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: -0.025em;
+  transition: all 0.3s ease;
+}
+
+.v2-side-link:hover {
+  background-color: rgba(30, 41, 59, 0.5);
+  color: #bae6fd;
+}
+
+.v2-side-link.active {
+  background-color: rgba(79, 215, 240, 0.1);
+  color: var(--v2-primary);
+  border-right: 4px solid var(--v2-primary);
+}
+
+.v2-aside-btn {
+  margin: auto 16px 0;
+  width: calc(100% - 32px);
+}
+
+.v2-tactical-main {
+  padding: 96px 24px 96px;
+}
+
+.tactical-main-bg {
+  background: radial-gradient(circle at 50% 50%, rgba(5, 34, 47, 1) 0%, rgba(0, 22, 32, 1) 100%);
+}
+
+.v2-tactical-bottom-nav {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 64px;
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  background-color: rgba(2, 6, 23, 0.9);
+  backdrop-filter: blur(16px);
+  border-top: 1px solid rgba(79, 215, 240, 0.2);
+  z-index: 50;
+}
+
+.v2-bottom-link {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  color: #64748b;
+  text-decoration: none;
+  padding: 8px;
+  transition: transform 0.2s ease;
+}
+
+.v2-bottom-link:active {
+  transform: scale(0.9);
+}
+
+.v2-bottom-link.active {
+  color: var(--v2-primary);
+  background-color: rgba(8, 51, 68, 0.4);
+  border-top: 2px solid var(--v2-primary);
+}
+
+.v2-bottom-label {
+  font-size: 10px;
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.v2-tactical-fab {
+  position: fixed;
+  bottom: 80px;
+  right: 24px;
+  width: 56px;
+  height: 56px;
+  border-radius: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 40;
+  border: none;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  background-color: var(--v2-primary);
+  color: var(--v2-on-primary);
+  box-shadow: 0 0 20px rgba(79, 215, 240, 0.4);
+}
+
+.v2-tactical-fab:active {
+  transform: scale(0.95);
+}
+
+@media (min-width: 1024px) {
+  .v2-tactical-main {
+    padding-left: 288px !important;
+  }
+}
+
+@media (max-width: 1023px) {
+  .lg-hidden {
+    display: flex !important;
+  }
+  .hidden-lg-down {
+    display: none !important;
+  }
+}
+
+@media (min-width: 1024px) {
+  .lg-hidden {
+    display: none !important;
+  }
+}
+
+@media (max-width: 767px) {
+  .md-hidden {
+    display: flex !important;
+  }
+  .hidden-md-down {
+    display: none !important;
+  }
+}
+
+@media (min-width: 768px) {
+  .md-hidden {
+    display: none !important;
+  }
+}
+</style>

--- a/src/views/v2/tactical/UnitDetailPage.vue
+++ b/src/views/v2/tactical/UnitDetailPage.vue
@@ -1,0 +1,641 @@
+<template>
+  <div class="v2-unit-detail-page">
+    <!-- Unit Header Header Section -->
+    <header class="v2-unit-header">
+      <div class="scanline v2-header-scanline"></div>
+      <div>
+        <div class="v2-badge-row">
+          <span class="v2-badge-v2 badge-primary">Heavy Warjack</span>
+          <span class="v2-badge-v2 badge-secondary">Class 03</span>
+        </div>
+        <h1 class="font-headline v2-unit-title">Slayer Warjack</h1>
+        <p class="font-headline v2-unit-subtitle">Cryx Faction // Dragon-Lich Chassis</p>
+      </div>
+      <div class="v2-pts-col">
+        <div class="v2-pts-box-v2">
+          <div class="pts-box-corner"></div>
+          <span class="font-headline pts-box-label">Points</span>
+          <span class="font-headline pts-box-value">10</span>
+        </div>
+      </div>
+    </header>
+
+    <!-- Tactical Grid Layout -->
+    <div class="v2-detail-grid">
+      <!-- Left Column: Unit Portrait & Bio -->
+      <div class="v2-detail-col-left">
+        <div class="v2-portrait-container-v2">
+          <img class="v2-portrait-img-v2" src="https://lh3.googleusercontent.com/aida-public/AB6AXuCQHa5dX_1BdRqDoc1EvRjR-C5yy1CSEn-ySNuR_ajHfLxUjbAegYWn9rhIHdRR05lcJiqEJ6aWa7_uc6aaWNQ9mFd8autkuZkKF_LTibc7VNhIRJO3N2Dj0ZgfyGpp6bdhf_T8cECH6Rt6DVFxrIlBNuEknYuvPz0mqOE_2e6lt-ZmLkYpbV8l04hEG5-OUFxh0G58BHXfLJIxz0zrdmQvElvx1oR7e_jQGHEzD0qA9OOglUl2lKKr5nw92yFr1QtICmmvt69hioe_"/>
+          <div class="portrait-overlay"></div>
+          <div class="portrait-bio">
+            <div class="bio-accent-bars">
+              <div class="bar-full"></div>
+              <div class="bar-mid"></div>
+              <div class="bar-small"></div>
+            </div>
+            <p class="font-body bio-text">
+              Built for pure destruction, the Slayer is the apex of necro-mechanika. Its twin tusks and hydraulic talons are designed to shred iron and bone with equal ease.
+            </p>
+          </div>
+        </div>
+        <!-- Keywords Chip Cloud -->
+        <div class="v2-keywords-row">
+          <div v-for="keyword in keywords" :key="keyword" class="v2-keyword-chip">{{ keyword }}</div>
+        </div>
+      </div>
+
+      <!-- Right Column: Stats & Data -->
+      <div class="v2-detail-col-right">
+        <!-- Stats Readout - HUD Style -->
+        <section class="v2-stats-hud">
+          <div class="scanline hud-scanline-inner"></div>
+          <div class="hud-header">
+            <span class="material-symbols-outlined hud-icon">analytics</span>
+            <h2 class="font-headline hud-title">Core Performance Metrics</h2>
+          </div>
+          <div class="v2-stats-row">
+            <div v-for="(val, stat) in stats" :key="stat" class="v2-stat-item">
+              <div class="v2-stat-box-inner">
+                <div class="stat-glow"></div>
+                <span class="font-headline v2-stat-val">{{ val }}</span>
+              </div>
+              <span class="font-headline v2-stat-label">{{ stat }}</span>
+            </div>
+          </div>
+        </section>
+
+        <!-- Armament & Systems -->
+        <section class="v2-weapon-section">
+          <div class="weapon-section-header">
+            <h2 class="font-headline weapon-section-title">Weapon Systems</h2>
+            <div class="weapon-section-accents">
+              <div class="accent-dot"></div>
+              <div class="accent-dot"></div>
+              <div class="accent-dot dim"></div>
+            </div>
+          </div>
+          <div v-for="weapon in weapons" :key="weapon.name" class="v2-weapon-card-v2">
+            <div class="weapon-card-info">
+              <div class="font-headline weapon-type-label">{{ weapon.type }}</div>
+              <h3 class="font-headline weapon-name-v2">{{ weapon.name }}</h3>
+            </div>
+            <div class="weapon-card-stats">
+              <div v-for="(val, label) in weapon.stats" :key="label" :class="{ 'text-primary': label === 'P+S' }">
+                <div class="font-headline weapon-stat-label">{{ label }}</div>
+                <div class="font-headline weapon-stat-value">{{ val }}</div>
+              </div>
+            </div>
+            <div v-if="weapon.note" class="weapon-note-badge">{{ weapon.note }}</div>
+          </div>
+        </section>
+
+        <!-- Special Rules -->
+        <section class="v2-rules-section">
+          <h2 class="font-headline rules-section-title">Combat Directives</h2>
+          <div class="v2-rules-grid">
+            <div v-for="rule in specialRules" :key="rule.name" class="v2-rule-box-v2" :style="{ borderTopColor: rule.borderColorValue }">
+              <h4 class="font-headline rule-title-v2" :style="{ color: rule.textColorValue }">{{ rule.name }}</h4>
+              <p class="rule-desc-v2">{{ rule.description }}</p>
+            </div>
+          </div>
+        </section>
+
+        <!-- Damage Grid Visualization -->
+        <section class="v2-damage-section">
+          <div class="damage-section-header">
+            <h2 class="font-headline damage-section-title">Damage Tracking Overlay</h2>
+            <div class="font-headline damage-legend">
+              <span class="legend-item"><span class="dot-ok"></span> OK</span>
+              <span class="legend-item"><span class="dot-crit"></span> CRIT</span>
+            </div>
+          </div>
+          <div class="v2-damage-grid-v2">
+            <div v-for="(cell, i) in damageGrid" :key="i"
+              class="damage-cell-v2"
+              :class="[
+                cell.type === 'empty' ? 'cell-empty' : cell.type === 'crit' ? 'cell-crit' : 'cell-ok',
+                cell.filled ? 'cell-filled' : ''
+              ]">
+              {{ cell.label }}
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+const keywords = ['Construct', 'Pathfinder', 'Abomination', 'Soul Taker']
+const stats = { SPD: 6, STR: 10, MAT: 6, RAT: 3, DEF: 17, ARM: 17 }
+const weapons = [
+  { type: 'Melee Weapon', name: 'Death Claw (L)', stats: { RNG: '2"', POW: 6, 'P+S': 16 }, note: 'Open Fist' },
+  { type: 'Melee Weapon', name: 'Death Claw (R)', stats: { RNG: '2"', POW: 6, 'P+S': 16 } }
+]
+const specialRules = [
+  { name: 'Combo Strike', description: 'During its activation, this model can make one melee attack with both Death Claws. The POW is equal to the STR of this model plus twice the POW of the weapons.', borderColorValue: '#ffb68b', textColorValue: '#ffb68b' },
+  { name: 'Sustained Attack', description: 'During its activation, this model can spend 1 focus point to automatically hit with all subsequent attacks against the same target.', borderColorValue: '#4fd7f0', textColorValue: '#4fd7f0' }
+]
+
+const damageGrid = [
+  { label: 'L', type: 'ok' }, { label: '', type: 'ok' }, { label: '', type: 'ok' }, { label: '', type: 'ok' }, { label: '', type: 'ok' }, { label: 'R', type: 'ok' },
+  { label: '', type: 'ok' }, { label: '', type: 'ok' }, { label: 'M', type: 'crit' }, { label: 'M', type: 'crit' }, { label: '', type: 'ok' }, { label: '', type: 'ok' },
+  { label: '', type: 'ok' }, { label: 'C', type: 'crit' }, { label: '', type: 'empty' }, { label: '', type: 'empty' }, { label: 'C', type: 'crit' }, { label: '', type: 'ok' },
+  { label: '', type: 'ok' }, { label: '', type: 'empty' }, { label: '', type: 'empty' }, { label: '', type: 'empty' }, { label: '', type: 'empty' }, { label: '', type: 'ok' }
+]
+</script>
+
+<style scoped>
+.v2-unit-detail-page {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 16px;
+}
+
+.v2-unit-header {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 48px;
+  position: relative;
+  overflow: hidden;
+  padding: 32px;
+  border-left: 4px solid var(--v2-primary);
+  background: linear-gradient(to right, var(--v2-surface-container-high), transparent);
+}
+
+.v2-header-scanline {
+  position: absolute;
+  inset: 0;
+  opacity: 0.1;
+}
+
+@media (min-width: 768px) {
+  .v2-unit-header {
+    flex-direction: row;
+    align-items: flex-end;
+  }
+}
+
+.v2-badge-row {
+  display: flex;
+  align-items: center; gap: 12px; margin-bottom: 8px;
+}
+
+.v2-badge-v2 {
+  padding: 4px 12px;
+  font-size: 10px;
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  border-width: 1px;
+  border-style: solid;
+}
+
+.badge-primary { background-color: rgba(79, 215, 240, 0.1); color: var(--v2-primary); border-color: rgba(79, 215, 240, 0.2); }
+.badge-secondary { background-color: rgba(255, 182, 139, 0.1); color: var(--v2-secondary); border-color: rgba(255, 182, 139, 0.2); }
+
+.v2-unit-title {
+  font-size: 48px;
+  font-weight: 900;
+  color: var(--v2-on-surface);
+  letter-spacing: -0.05em;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+
+.v2-unit-subtitle {
+  color: rgba(79, 215, 240, 0.6);
+  font-weight: 700;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  font-size: 14px;
+}
+
+.v2-pts-col {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+}
+
+.v2-pts-box-v2 {
+  background-color: var(--v2-primary-container);
+  color: var(--v2-on-primary-container);
+  padding: 24px;
+  width: 96px;
+  height: 96px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  box-sizing: border-box;
+}
+
+.pts-box-corner {
+  position: absolute;
+  top: -4px;
+  left: -4px;
+  width: 12px;
+  height: 12px;
+  border-top: 2px solid var(--v2-primary);
+  border-left: 2px solid var(--v2-primary);
+}
+
+.pts-box-label {
+  font-size: 12px;
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: -0.05em;
+  opacity: 0.7;
+}
+
+.pts-box-value {
+  font-size: 36px;
+  font-weight: 900;
+  font-style: italic;
+  line-height: 1;
+}
+
+.v2-detail-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 32px;
+}
+
+@media (min-width: 1024px) {
+  .v2-detail-grid {
+    grid-template-columns: repeat(12, 1fr);
+  }
+  .v2-detail-col-left { grid-column: span 5; }
+  .v2-detail-col-right { grid-column: span 7; }
+}
+
+.v2-portrait-container-v2 {
+  position: relative;
+  aspect-ratio: 4/5;
+  background-color: var(--v2-surface-container-low);
+  overflow: hidden;
+}
+
+.v2-portrait-img-v2 {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: grayscale(1) brightness(0.75);
+  transition: all 0.7s ease;
+  opacity: 0.8;
+}
+
+.v2-portrait-container-v2:hover .v2-portrait-img-v2 {
+  filter: grayscale(0);
+  transform: scale(1.05);
+}
+
+.portrait-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to top, var(--v2-surface), transparent, transparent);
+}
+
+.portrait-bio {
+  position: absolute;
+  bottom: 24px;
+  left: 24px;
+  right: 24px;
+}
+
+.bio-accent-bars {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 16px;
+}
+
+.bar-full { height: 4px; width: 32px; background-color: var(--v2-primary); }
+.bar-mid { height: 4px; width: 16px; background-color: rgba(79, 215, 240, 0.3); }
+.bar-small { height: 4px; width: 8px; background-color: rgba(79, 215, 240, 0.3); }
+
+.bio-text {
+  font-size: 14px;
+  color: var(--v2-on-surface-variant);
+  font-style: italic;
+  line-height: 1.625;
+}
+
+.v2-keywords-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 24px;
+}
+
+.v2-keyword-chip {
+  background-color: var(--v2-surface-container-highest);
+  padding: 8px 16px;
+  font-family: var(--v2-font-headline);
+  font-size: 10px;
+  font-weight: 900;
+  color: var(--v2-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  border: 1px solid rgba(79, 215, 240, 0.1);
+}
+
+.v2-stats-hud {
+  background-color: var(--v2-surface-container-low);
+  padding: 32px;
+  position: relative;
+  overflow: hidden;
+  box-sizing: border-box;
+}
+
+.hud-scanline-inner {
+  position: absolute;
+  inset: 0;
+  opacity: 0.05;
+}
+
+.hud-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 32px;
+}
+
+.hud-icon {
+  color: var(--v2-primary);
+  font-size: 14px;
+}
+
+.hud-title {
+  font-weight: 900;
+  text-transform: uppercase;
+  font-size: 12px;
+  letter-spacing: 0.1em;
+  color: var(--v2-primary);
+}
+
+.v2-stats-row {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+
+@media (min-width: 768px) {
+  .v2-stats-row {
+    grid-template-columns: repeat(6, 1fr);
+  }
+}
+
+.v2-stat-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.v2-stat-box-inner {
+  width: 100%;
+  aspect-ratio: 1/1;
+  border: 1px solid rgba(60, 73, 76, 0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+}
+
+.v2-stat-val {
+  font-size: 24px;
+  font-weight: 900;
+  color: var(--v2-on-surface);
+  position: relative;
+}
+
+.v2-stat-label {
+  margin-top: 8px;
+  font-size: 10px;
+  font-weight: 900;
+  color: var(--v2-outline);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.stat-glow {
+  position: absolute;
+  inset: 0;
+  background-color: rgba(79, 215, 240, 0.05);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.v2-stat-box-inner:hover .stat-glow {
+  opacity: 1;
+}
+
+.v2-weapon-section {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  margin-top: 32px;
+}
+
+.weapon-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid rgba(60, 73, 76, 0.2);
+  padding-bottom: 16px;
+}
+
+.weapon-section-title {
+  font-weight: 900;
+  text-transform: uppercase;
+  font-size: 18px;
+  letter-spacing: -0.025em;
+  color: var(--v2-on-surface);
+}
+
+.weapon-section-accents {
+  display: flex;
+  gap: 4px;
+}
+
+.accent-dot { width: 4px; height: 4px; background-color: var(--v2-primary); }
+.accent-dot.dim { background-color: rgba(79, 215, 240, 0.2); }
+
+.v2-weapon-card-v2 {
+  background-color: var(--v2-surface-container);
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  position: relative;
+  box-sizing: border-box;
+}
+
+@media (min-width: 768px) {
+  .v2-weapon-card-v2 {
+    flex-direction: row;
+  }
+  .weapon-card-info { width: 33.333333%; }
+}
+
+.weapon-type-label {
+  font-size: 10px;
+  font-weight: 900;
+  color: var(--v2-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  margin-bottom: 4px;
+}
+
+.weapon-name-v2 {
+  font-size: 20px;
+  font-weight: 700;
+  text-transform: uppercase;
+  color: var(--v2-on-surface);
+}
+
+.weapon-card-stats {
+  flex: 1;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+  border-left: 1px solid rgba(60, 73, 76, 0.2);
+  padding-left: 24px;
+}
+
+.text-primary { color: var(--v2-primary); }
+
+.weapon-stat-label {
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--v2-outline);
+  text-transform: uppercase;
+}
+
+.weapon-stat-value {
+  font-size: 20px;
+  font-weight: 900;
+}
+
+.weapon-note-badge {
+  position: absolute;
+  top: 0;
+  right: 0;
+  background-color: rgba(79, 215, 240, 0.1);
+  color: var(--v2-primary-fixed-dim);
+  padding: 4px 12px;
+  font-size: 8px;
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: -0.05em;
+}
+
+.v2-rules-section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-top: 32px;
+}
+
+.rules-section-title {
+  font-weight: 900;
+  text-transform: uppercase;
+  font-size: 12px;
+  letter-spacing: 0.1em;
+  color: var(--v2-outline);
+}
+
+.v2-rules-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 16px;
+}
+
+@media (min-width: 768px) {
+  .v2-rules-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.v2-rule-box-v2 {
+  background-color: var(--v2-surface-container-high);
+  padding: 16px;
+  border-top-width: 2px;
+  border-top-style: solid;
+}
+
+.rule-title-v2 {
+  font-weight: 900;
+  text-transform: uppercase;
+  font-size: 14px;
+  margin-bottom: 4px;
+}
+
+.rule-desc-v2 {
+  font-size: 12px;
+  color: var(--v2-on-surface-variant);
+  line-height: 1.625;
+}
+
+.v2-damage-section {
+  background-color: var(--v2-surface-container-low);
+  padding: 24px;
+  border: 1px solid rgba(134, 147, 150, 0.1);
+  box-sizing: border-box;
+  margin-top: 32px;
+}
+
+.damage-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 24px;
+}
+
+.damage-section-title {
+  font-weight: 900;
+  text-transform: uppercase;
+  font-size: 12px;
+  letter-spacing: 0.1em;
+  color: var(--v2-primary);
+}
+
+.damage-legend {
+  display: flex;
+  gap: 8px;
+  font-size: 10px;
+  color: var(--v2-outline);
+}
+
+.legend-item { display: flex; align-items: center; gap: 4px; }
+.dot-ok { width: 8px; height: 8px; background-color: var(--v2-primary); }
+.dot-crit { width: 8px; height: 8px; background-color: var(--v2-error); }
+
+.v2-damage-grid-v2 {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 8px;
+  max-width: 384px;
+  margin: 0 auto;
+}
+
+.damage-cell-v2 {
+  aspect-ratio: 1/1;
+  border-width: 1px;
+  border-style: solid;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 8px;
+  font-weight: 900;
+  box-sizing: border-box;
+}
+
+.cell-empty { border-color: rgba(60, 73, 76, 0.2); color: transparent; }
+.cell-crit { border-color: rgba(255, 180, 171, 0.4); background-color: rgba(255, 180, 171, 0.2); color: var(--v2-error); }
+.cell-ok { border-color: rgba(79, 215, 240, 0.4); background-color: rgba(79, 215, 240, 0.2); color: var(--v2-primary); }
+.cell-filled.cell-crit { background-color: rgba(255, 180, 171, 0.4); }
+.cell-filled.cell-ok { background-color: rgba(79, 215, 240, 0.4); }
+</style>

--- a/src/views/v2/tactical/UnitDetailPageV2.vue
+++ b/src/views/v2/tactical/UnitDetailPageV2.vue
@@ -1,0 +1,677 @@
+<template>
+  <div class="v2-unit-detail-page">
+    <!-- Unit Header Header Section -->
+    <header class="v2-unit-header">
+      <div class="scanline v2-header-scanline"></div>
+      <div>
+        <div class="v2-badge-row">
+          <span class="v2-badge-v2 badge-primary">Heavy Warjack</span>
+          <span class="v2-badge-v2 badge-secondary">Class 03</span>
+        </div>
+        <h1 class="font-headline v2-unit-title">Slayer Warjack</h1>
+        <p class="font-headline v2-unit-subtitle">Cryx Faction // Dragon-Lich Chassis</p>
+      </div>
+      <div class="v2-pts-col">
+        <div class="v2-pts-box-v2">
+          <div class="pts-box-corner"></div>
+          <span class="font-headline pts-box-label">Points</span>
+          <span class="font-headline pts-box-value">10</span>
+        </div>
+      </div>
+    </header>
+
+    <!-- Tactical Grid Layout -->
+    <div class="v2-detail-grid">
+      <!-- Left Column: Unit Portrait & Bio -->
+      <div class="v2-detail-col-left">
+        <div class="v2-portrait-container-v2">
+          <img class="v2-portrait-img-v2" src="https://lh3.googleusercontent.com/aida-public/AB6AXuCQHa5dX_1BdRqDoc1EvRjR-C5yy1CSEn-ySNuR_ajHfLxUjbAegYWn9rhIHdRR05lcJiqEJ6aWa7_uc6aaWNQ9mFd8autkuZkKF_LTibc7VNhIRJO3N2Dj0ZgfyGpp6bdhf_T8cECH6Rt6DVFxrIlBNuEknYuvPz0mqOE_2e6lt-ZmLkYpbV8l04hEG5-OUFxh0G58BHXfLJIxz0zrdmQvElvx1oR7e_jQGHEzD0qA9OOglUl2lKKr5nw92yFr1QtICmmvt69hioe_"/>
+          <div class="portrait-overlay"></div>
+          <div class="portrait-bio">
+            <div class="bio-accent-bars">
+              <div class="bar-full"></div>
+              <div class="bar-mid"></div>
+              <div class="bar-small"></div>
+            </div>
+            <p class="font-body bio-text">
+              Built for pure destruction, the Slayer is the apex of necro-mechanika. Its twin tusks and hydraulic talons are designed to shred iron and bone with equal ease.
+            </p>
+          </div>
+        </div>
+        <!-- Keywords Chip Cloud -->
+        <div class="v2-keywords-row">
+          <div v-for="keyword in keywords" :key="keyword" class="v2-keyword-chip">{{ keyword }}</div>
+        </div>
+      </div>
+
+      <!-- Right Column: Stats & Data -->
+      <div class="v2-detail-col-right">
+        <!-- Stats Readout - HUD Style -->
+        <section class="v2-stats-hud">
+          <div class="scanline hud-scanline-inner"></div>
+          <div class="hud-header">
+            <span class="material-symbols-outlined hud-icon">analytics</span>
+            <h2 class="font-headline hud-title">Core Performance Metrics</h2>
+          </div>
+          <div class="v2-stats-row">
+            <div v-for="(val, stat) in stats" :key="stat" class="v2-stat-item">
+              <div class="v2-stat-box-inner">
+                <div class="stat-glow"></div>
+                <span class="font-headline v2-stat-val">{{ val }}</span>
+              </div>
+              <span class="font-headline v2-stat-label">{{ stat }}</span>
+            </div>
+          </div>
+        </section>
+
+        <!-- Armament & Systems -->
+        <section class="v2-weapon-section">
+          <div class="weapon-section-header">
+            <h2 class="font-headline weapon-section-title">Weapon Systems</h2>
+            <div class="weapon-section-accents">
+              <div class="accent-dot"></div>
+              <div class="accent-dot"></div>
+              <div class="accent-dot dim"></div>
+            </div>
+          </div>
+          <div v-for="weapon in weapons" :key="weapon.name" class="v2-weapon-card-v2">
+            <div class="weapon-card-info">
+              <div class="font-headline weapon-type-label">{{ weapon.type }}</div>
+              <h3 class="font-headline weapon-name-v2">{{ weapon.name }}</h3>
+            </div>
+            <div class="weapon-card-stats">
+              <div v-for="(val, label) in weapon.stats" :key="label" :class="{ 'text-primary': label === 'P+S' }">
+                <div class="font-headline weapon-stat-label">{{ label }}</div>
+                <div class="font-headline weapon-stat-value">{{ val }}</div>
+              </div>
+            </div>
+            <div v-if="weapon.note" class="weapon-note-badge">{{ weapon.note }}</div>
+          </div>
+        </section>
+
+        <!-- Special Rules -->
+        <section class="v2-rules-section">
+          <h2 class="font-headline rules-section-title">Combat Directives</h2>
+          <div class="v2-rules-grid">
+            <div v-for="rule in specialRules" :key="rule.name" class="v2-rule-box-v2" :style="{ borderTopColor: rule.borderColorValue }">
+              <h4 class="font-headline rule-title-v2" :style="{ color: rule.textColorValue }">{{ rule.name }}</h4>
+              <p class="rule-desc-v2">{{ rule.description }}</p>
+            </div>
+          </div>
+        </section>
+
+        <!-- Damage Grid Visualization (Screen 5 Variant) -->
+        <section class="v2-damage-section">
+          <div class="damage-section-header">
+            <h2 class="font-headline damage-section-title">Damage Tracking Overlay</h2>
+            <div class="font-headline damage-legend">
+              <span class="legend-item"><span class="dot-ok"></span> OK</span>
+              <span class="legend-item"><span class="dot-crit"></span> CRIT</span>
+            </div>
+          </div>
+          <div class="v2-irregular-grid">
+            <!-- Row 4 (Top) -->
+            <div class="v2-grid-row row-4">
+              <div class="damage-cell-v2 cell-ok"></div>
+              <div class="damage-cell-v2 cell-ok"></div>
+            </div>
+            <!-- Row 3 -->
+            <div class="v2-grid-row row-3">
+              <div class="damage-cell-v2 cell-ok"></div>
+              <div class="damage-cell-v2 cell-crit">M</div>
+              <div class="damage-cell-v2 cell-crit">M</div>
+              <div class="damage-cell-v2 cell-ok"></div>
+            </div>
+            <!-- Row 2 -->
+            <div class="v2-grid-row row-2">
+              <div class="damage-cell-v2 cell-ok"></div>
+              <div class="damage-cell-v2 cell-ok"></div>
+              <div class="damage-cell-v2 cell-crit">C</div>
+              <div class="damage-cell-v2 cell-crit">C</div>
+              <div class="damage-cell-v2 cell-ok"></div>
+              <div class="damage-cell-v2 cell-ok"></div>
+            </div>
+            <!-- Bottom Row (Row 1) -->
+            <div class="v2-grid-row row-1">
+              <div class="damage-cell-v2 cell-ok label-primary">L</div>
+              <div class="damage-cell-v2 cell-crit">M</div>
+              <div class="damage-cell-v2 cell-crit">C</div>
+              <div class="damage-cell-v2 cell-crit">C</div>
+              <div class="damage-cell-v2 cell-crit">M</div>
+              <div class="damage-cell-v2 cell-ok label-primary">R</div>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+const keywords = ['Construct', 'Pathfinder', 'Abomination', 'Soul Taker']
+const stats = { SPD: 6, STR: 10, MAT: 6, RAT: 3, DEF: 17, ARM: 17 }
+const weapons = [
+  { type: 'Melee Weapon', name: 'Death Claw (L)', stats: { RNG: '2"', POW: 6, 'P+S': 16 }, note: 'Open Fist' },
+  { type: 'Melee Weapon', name: 'Death Claw (R)', stats: { RNG: '2"', POW: 6, 'P+S': 16 } }
+]
+const specialRules = [
+  { name: 'Combo Strike', description: 'During its activation, this model can make one melee attack with both Death Claws. The POW is equal to the STR of this model plus twice the POW of the weapons.', borderColorValue: '#ffb68b', textColorValue: '#ffb68b' },
+  { name: 'Sustained Attack', description: 'During its activation, this model can spend 1 focus point to automatically hit with all subsequent attacks against the same target.', borderColorValue: '#4fd7f0', textColorValue: '#4fd7f0' }
+]
+</script>
+
+<style scoped>
+.v2-unit-detail-page {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 16px;
+}
+
+.v2-unit-header {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 48px;
+  position: relative;
+  overflow: hidden;
+  padding: 32px;
+  border-left: 4px solid var(--v2-primary);
+  background: linear-gradient(to right, var(--v2-surface-container-high), transparent);
+}
+
+.v2-header-scanline {
+  position: absolute;
+  inset: 0;
+  opacity: 0.1;
+}
+
+@media (min-width: 768px) {
+  .v2-unit-header {
+    flex-direction: row;
+    align-items: flex-end;
+  }
+}
+
+.v2-badge-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.v2-badge-v2 {
+  padding: 4px 12px;
+  font-size: 10px;
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  border-width: 1px;
+  border-style: solid;
+}
+
+.badge-primary { background-color: rgba(79, 215, 240, 0.1); color: var(--v2-primary); border-color: rgba(79, 215, 240, 0.2); }
+.badge-secondary { background-color: rgba(255, 182, 139, 0.1); color: var(--v2-secondary); border-color: rgba(255, 182, 139, 0.2); }
+
+.v2-unit-title {
+  font-size: 48px;
+  font-weight: 900;
+  color: var(--v2-on-surface);
+  letter-spacing: -0.05em;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+
+.v2-unit-subtitle {
+  color: rgba(79, 215, 240, 0.6);
+  font-weight: 700;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  font-size: 14px;
+}
+
+.v2-pts-col {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+}
+
+.v2-pts-box-v2 {
+  background-color: var(--v2-primary-container);
+  color: var(--v2-on-primary-container);
+  padding: 24px;
+  width: 96px;
+  height: 96px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  box-sizing: border-box;
+}
+
+.pts-box-corner {
+  position: absolute;
+  top: -4px;
+  left: -4px;
+  width: 12px;
+  height: 12px;
+  border-top: 2px solid var(--v2-primary);
+  border-left: 2px solid var(--v2-primary);
+}
+
+.pts-box-label {
+  font-size: 12px;
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: -0.05em;
+  opacity: 0.7;
+}
+
+.pts-box-value {
+  font-size: 36px;
+  font-weight: 900;
+  font-style: italic;
+  line-height: 1;
+}
+
+.v2-detail-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 32px;
+}
+
+@media (min-width: 1024px) {
+  .v2-detail-grid {
+    grid-template-columns: repeat(12, 1fr);
+  }
+  .v2-detail-col-left { grid-column: span 5; }
+  .v2-detail-col-right { grid-column: span 7; }
+}
+
+.v2-portrait-container-v2 {
+  position: relative;
+  aspect-ratio: 4/5;
+  background-color: var(--v2-surface-container-low);
+  overflow: hidden;
+}
+
+.v2-portrait-img-v2 {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: grayscale(1) brightness(0.75);
+  transition: all 0.7s ease;
+  opacity: 0.8;
+}
+
+.v2-portrait-container-v2:hover .v2-portrait-img-v2 {
+  filter: grayscale(0);
+  transform: scale(1.05);
+}
+
+.portrait-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to top, var(--v2-surface), transparent, transparent);
+}
+
+.portrait-bio {
+  position: absolute;
+  bottom: 24px;
+  left: 24px;
+  right: 24px;
+}
+
+.bio-accent-bars {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 16px;
+}
+
+.bar-full { height: 4px; width: 32px; background-color: var(--v2-primary); }
+.bar-mid { height: 4px; width: 16px; background-color: rgba(79, 215, 240, 0.3); }
+.bar-small { height: 4px; width: 8px; background-color: rgba(79, 215, 240, 0.3); }
+
+.bio-text {
+  font-size: 14px;
+  color: var(--v2-on-surface-variant);
+  font-style: italic;
+  line-height: 1.625;
+}
+
+.v2-keywords-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 24px;
+}
+
+.v2-keyword-chip {
+  background-color: var(--v2-surface-container-highest);
+  padding: 8px 16px;
+  font-family: var(--v2-font-headline);
+  font-size: 10px;
+  font-weight: 900;
+  color: var(--v2-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  border: 1px solid rgba(79, 215, 240, 0.1);
+}
+
+.v2-stats-hud {
+  background-color: var(--v2-surface-container-low);
+  padding: 32px;
+  position: relative;
+  overflow: hidden;
+  box-sizing: border-box;
+}
+
+.hud-scanline-inner {
+  position: absolute;
+  inset: 0;
+  opacity: 0.05;
+}
+
+.hud-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 32px;
+}
+
+.hud-icon {
+  color: var(--v2-primary);
+  font-size: 14px;
+}
+
+.hud-title {
+  font-weight: 900;
+  text-transform: uppercase;
+  font-size: 12px;
+  letter-spacing: 0.1em;
+  color: var(--v2-primary);
+}
+
+.v2-stats-row {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+
+@media (min-width: 768px) {
+  .v2-stats-row {
+    grid-template-columns: repeat(6, 1fr);
+  }
+}
+
+.v2-stat-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.v2-stat-box-inner {
+  width: 100%;
+  aspect-ratio: 1/1;
+  border: 1px solid rgba(60, 73, 76, 0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+}
+
+.v2-stat-val {
+  font-size: 24px;
+  font-weight: 900;
+  color: var(--v2-on-surface);
+  position: relative;
+}
+
+.v2-stat-label {
+  margin-top: 8px;
+  font-size: 10px;
+  font-weight: 900;
+  color: var(--v2-outline);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.stat-glow {
+  position: absolute;
+  inset: 0;
+  background-color: rgba(79, 215, 240, 0.05);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.v2-stat-box-inner:hover .stat-glow {
+  opacity: 1;
+}
+
+.v2-weapon-section {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  margin-top: 32px;
+}
+
+.weapon-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid rgba(60, 73, 76, 0.2);
+  padding-bottom: 16px;
+}
+
+.weapon-section-title {
+  font-weight: 900;
+  text-transform: uppercase;
+  font-size: 18px;
+  letter-spacing: -0.025em;
+  color: var(--v2-on-surface);
+}
+
+.weapon-section-accents {
+  display: flex;
+  gap: 4px;
+}
+
+.accent-dot { width: 4px; height: 4px; background-color: var(--v2-primary); }
+.accent-dot.dim { background-color: rgba(79, 215, 240, 0.2); }
+
+.v2-weapon-card-v2 {
+  background-color: var(--v2-surface-container);
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  position: relative;
+  box-sizing: border-box;
+}
+
+@media (min-width: 768px) {
+  .v2-weapon-card-v2 {
+    flex-direction: row;
+  }
+  .weapon-card-info { width: 33.333333%; }
+}
+
+.weapon-type-label {
+  font-size: 10px;
+  font-weight: 900;
+  color: var(--v2-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  margin-bottom: 4px;
+}
+
+.weapon-name-v2 {
+  font-size: 20px;
+  font-weight: 700;
+  text-transform: uppercase;
+  color: var(--v2-on-surface);
+}
+
+.weapon-card-stats {
+  flex: 1;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+  border-left: 1px solid rgba(60, 73, 76, 0.2);
+  padding-left: 24px;
+}
+
+.text-primary { color: var(--v2-primary); }
+
+.weapon-stat-label {
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--v2-outline);
+  text-transform: uppercase;
+}
+
+.weapon-stat-value {
+  font-size: 20px;
+  font-weight: 900;
+}
+
+.weapon-note-badge {
+  position: absolute;
+  top: 0;
+  right: 0;
+  background-color: rgba(79, 215, 240, 0.1);
+  color: var(--v2-primary-fixed-dim);
+  padding: 4px 12px;
+  font-size: 8px;
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: -0.05em;
+}
+
+.v2-rules-section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-top: 32px;
+}
+
+.rules-section-title {
+  font-weight: 900;
+  text-transform: uppercase;
+  font-size: 12px;
+  letter-spacing: 0.1em;
+  color: var(--v2-outline);
+}
+
+.v2-rules-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 16px;
+}
+
+@media (min-width: 768px) {
+  .v2-rules-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.v2-rule-box-v2 {
+  background-color: var(--v2-surface-container-high);
+  padding: 16px;
+  border-top-width: 2px;
+  border-top-style: solid;
+}
+
+.rule-title-v2 {
+  font-weight: 900;
+  text-transform: uppercase;
+  font-size: 14px;
+  margin-bottom: 4px;
+}
+
+.rule-desc-v2 {
+  font-size: 12px;
+  color: var(--v2-on-surface-variant);
+  line-height: 1.625;
+}
+
+.v2-damage-section {
+  background-color: var(--v2-surface-container-low);
+  padding: 24px;
+  border: 1px solid rgba(134, 147, 150, 0.1);
+  box-sizing: border-box;
+  margin-top: 32px;
+}
+
+.damage-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 24px;
+}
+
+.damage-section-title {
+  font-weight: 900;
+  text-transform: uppercase;
+  font-size: 12px;
+  letter-spacing: 0.1em;
+  color: var(--v2-primary);
+}
+
+.damage-legend {
+  display: flex;
+  gap: 8px;
+  font-size: 10px;
+  color: var(--v2-outline);
+}
+
+.legend-item { display: flex; align-items: center; gap: 4px; }
+.dot-ok { width: 8px; height: 8px; background-color: var(--v2-primary); }
+.dot-crit { width: 8px; height: 8px; background-color: var(--v2-error); }
+
+.v2-irregular-grid {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  max-width: 384px;
+  margin: 0 auto;
+}
+
+.v2-grid-row {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  width: 100%;
+}
+
+.row-2, .row-1 {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  width: 100%;
+}
+
+.damage-cell-v2 {
+  aspect-ratio: 1/1;
+  border-width: 1px;
+  border-style: solid;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 8px;
+  font-weight: 900;
+  box-sizing: border-box;
+  width: 48px;
+  height: 48px;
+}
+
+.row-2 .damage-cell-v2, .row-1 .damage-cell-v2 {
+  width: auto;
+  height: auto;
+}
+
+.cell-crit { border-color: rgba(255, 180, 171, 0.4); background-color: rgba(255, 180, 171, 0.2); color: var(--v2-error); }
+.cell-ok { border-color: rgba(79, 215, 240, 0.4); background-color: rgba(79, 215, 240, 0.2); color: var(--v2-primary); }
+.label-primary { color: var(--v2-primary); background-color: rgba(79, 215, 240, 0.1); }
+</style>

--- a/src/views/v2/warhacker/ArmyBuilderPage.vue
+++ b/src/views/v2/warhacker/ArmyBuilderPage.vue
@@ -1,0 +1,425 @@
+<template>
+  <div class="v2-warhacker-builder">
+    <!-- POINTS HUD (Bento Style) -->
+    <section class="v2-warhacker-stats-grid">
+      <div class="v2-hud-card hud-card-primary">
+        <p class="font-label v2-hud-label">Combat Efficiency</p>
+        <div class="v2-hud-value-row">
+          <span class="font-headline v2-hud-val-main">41</span>
+          <span class="font-headline v2-hud-val-total">/ 75</span>
+        </div>
+        <div class="v2-hud-progress-bg">
+          <div class="v2-hud-progress-bar bg-primary shadow-primary" :style="{ width: '54.6%' }"></div>
+        </div>
+      </div>
+      <div class="v2-hud-card hud-card-tertiary">
+        <p class="font-label v2-hud-label">Warjack Points</p>
+        <div class="v2-hud-value-row">
+          <span class="font-headline v2-hud-val-tertiary">12</span>
+          <span class="font-headline v2-hud-val-total">/ 28</span>
+        </div>
+        <div class="v2-hud-progress-bg">
+          <div class="v2-hud-progress-bar bg-tertiary shadow-tertiary" :style="{ width: '42.8%' }"></div>
+        </div>
+      </div>
+    </section>
+
+    <!-- DIAGNOSTIC WARNINGS -->
+    <section class="v2-warhacker-diagnostic glass-panel">
+      <span class="material-symbols-outlined v2-diag-icon">warning</span>
+      <div>
+        <h4 class="font-label v2-diag-title">Critical System Error</h4>
+        <p class="v2-diag-desc">COMMAND LIMIT BREACH: FACTION PROTOCOL REQUIRES SECONDARY ATTACHMENT.</p>
+      </div>
+    </section>
+
+    <!-- ARMY LIST SECTION -->
+    <div class="v2-warhacker-list-stack">
+      <!-- WARCASTERS -->
+      <section class="v2-builder-list-section">
+        <div class="v2-builder-list-header">
+          <h2 class="font-headline v2-list-section-title">Leadership_Core</h2>
+          <span class="font-label v2-list-section-meta">01 / 01</span>
+        </div>
+        <div class="v2-warhacker-unit-card-v2 border-primary-dim">
+          <div class="v2-card-flex">
+            <div class="v2-card-portrait-box">
+              <img class="v2-img-unit grayscale-80" src="https://lh3.googleusercontent.com/aida-public/AB6AXuCMxyuf_URR49y8ujHkgLO6yFFdG1klLckvuCX9uAYpZ_L_TFvz6LUFkusgDaopma-xkHAUia0c_fsvUhwQPXJcjGHUbzh36U8quhCAty9GmmdPPk_WixwpByQ7AqwlYt1ZCbogjezWIBgoOilBRpS-T27V-0uCfvCbX1JwQhBP3oqkpF20jq61mEeUl3tre-EoiPCDoXYKilQPoKtFNli_ONPuivyDsmnDcXALuoLdt1mEnE7Z7yjIYV1DmdPmYHNz3dkRZjWKW5TW"/>
+            </div>
+            <div class="v2-card-details">
+              <div class="v2-pts-overlay">00 PTS</div>
+              <h3 class="font-headline v2-unit-card-title">Commander Stryker</h3>
+              <p class="font-label v2-unit-card-subtitle">Cygnar Warcaster</p>
+              <div class="v2-unit-stats-grid">
+                <div class="v2-unit-stat-item"><p class="font-label v2-stat-label">SPD</p><p class="font-headline v2-stat-val">6</p></div>
+                <div class="v2-unit-stat-item"><p class="font-label v2-stat-label">STR</p><p class="font-headline v2-stat-val">6</p></div>
+                <div class="v2-unit-stat-item"><p class="font-label v2-stat-label">ARM</p><p class="font-headline v2-stat-val">16</p></div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- WARJACKS -->
+      <section class="v2-builder-list-section">
+        <div class="v2-builder-list-header">
+          <h2 class="font-headline v2-list-section-title">Heavy_Chassis_Support</h2>
+          <span class="font-label v2-list-section-meta">02 / --</span>
+        </div>
+        <!-- Expanded Card -->
+        <div class="v2-warhacker-jack-expanded">
+          <div class="v2-jack-header">
+            <div class="v2-jack-identity">
+              <span class="material-symbols-outlined text-tertiary">robot_2</span>
+              <div>
+                <h3 class="font-headline v2-jack-name">Ironclad</h3>
+                <p class="font-label v2-jack-type">Heavy Warjack</p>
+              </div>
+            </div>
+            <div class="v2-jack-pts-row">
+              <span class="font-headline v2-jack-pts">12 PTS</span>
+              <span class="material-symbols-outlined v2-expand-icon">expand_less</span>
+            </div>
+          </div>
+          <div class="v2-jack-details">
+            <div class="v2-jack-stats-grid">
+              <div v-for="stat in ['MAT', 'RAT', 'DEF', 'ARM']" :key="stat" class="v2-jack-stat-box">
+                <p class="font-label v2-jack-stat-label">{{ stat }}</p>
+                <p class="font-headline v2-jack-stat-val">7</p>
+              </div>
+            </div>
+            <div>
+              <p class="font-label v2-weapon-section-label">Weapon Systems</p>
+              <div class="v2-weapon-row">
+                <span class="v2-weapon-name">Quake Hammer</span>
+                <span class="font-label v2-weapon-pow">POW 18</span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <!-- Collapsed Card -->
+        <div class="v2-warhacker-unit-item-v2">
+          <div class="v2-jack-identity">
+            <span class="material-symbols-outlined v2-collapsed-icon">robot_2</span>
+            <div>
+              <h3 class="font-headline v2-jack-name">Charger</h3>
+              <p class="font-label v2-jack-type">Light Warjack</p>
+            </div>
+          </div>
+          <div class="v2-jack-pts-row">
+            <span class="font-headline v2-jack-pts-collapsed">09 PTS</span>
+            <span class="material-symbols-outlined v2-expand-icon">expand_more</span>
+          </div>
+        </div>
+      </section>
+
+      <!-- UNITS -->
+      <section class="v2-builder-list-section p-bottom-48">
+        <div class="v2-builder-list-header">
+          <h2 class="font-headline v2-list-section-title">Infantry_Divisions</h2>
+          <span class="font-label v2-list-section-meta">01 / --</span>
+        </div>
+        <div class="v2-warhacker-unit-item-v2 border-top-soft">
+          <div class="v2-jack-identity">
+            <span class="material-symbols-outlined v2-collapsed-icon">groups</span>
+            <div>
+              <h3 class="font-headline v2-jack-name">Stormblades</h3>
+              <p class="font-label v2-jack-type">Unit (5 Models)</p>
+            </div>
+          </div>
+          <div class="v2-jack-pts-row">
+            <span class="font-headline v2-jack-pts-collapsed">10 PTS</span>
+            <span class="material-symbols-outlined v2-expand-icon">expand_more</span>
+          </div>
+        </div>
+      </section>
+    </div>
+
+    <!-- FAB: Add Unit -->
+    <button class="v2-warhacker-fab-add">
+      <span class="material-symbols-outlined v2-fab-icon">add</span>
+    </button>
+  </div>
+</template>
+
+<style scoped>
+.v2-warhacker-builder {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  box-sizing: border-box;
+}
+
+.v2-warhacker-stats-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+.v2-hud-card {
+  background-color: var(--v2-surface-container-low);
+  padding: 16px;
+  position: relative;
+  overflow: hidden;
+  border-top: 1px solid transparent;
+}
+
+.hud-card-primary { border-top-color: rgba(79, 215, 240, 0.3); }
+.hud-card-tertiary { border-top-color: rgba(0, 218, 243, 0.3); }
+
+.v2-hud-label {
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  color: var(--v2-on-surface-variant);
+  text-transform: uppercase;
+  margin-bottom: 4px;
+}
+
+.v2-hud-value-row {
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+}
+
+.v2-hud-val-main { font-size: 36px; font-weight: 700; color: var(--v2-primary); }
+.v2-hud-val-tertiary { font-size: 36px; font-weight: 700; color: var(--v2-tertiary); }
+.v2-hud-val-total { font-size: 20px; color: var(--v2-on-surface-variant); }
+
+.v2-hud-progress-bg {
+  margin-top: 12px;
+  width: 100%;
+  background-color: var(--v2-surface-container);
+  height: 4px;
+}
+
+.v2-hud-progress-bar {
+  height: 100%;
+}
+
+.bg-primary { background-color: var(--v2-primary); }
+.bg-tertiary { background-color: var(--v2-tertiary); }
+.shadow-primary { box-shadow: 0 0 8px var(--v2-primary); }
+.shadow-tertiary { box-shadow: 0 0 8px var(--v2-tertiary); }
+
+.v2-warhacker-diagnostic {
+  background-color: rgba(255, 182, 139, 0.05);
+  border-left: 2px solid var(--v2-secondary);
+  padding: 12px;
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.v2-diag-icon { color: var(--v2-secondary); font-variation-settings: 'FILL' 1; }
+.v2-diag-title { font-size: 11px; font-weight: 700; color: var(--v2-secondary); letter-spacing: 0.1em; text-transform: uppercase; }
+.v2-diag-desc { font-size: 12px; color: rgba(255, 182, 139, 0.8); font-weight: 500; }
+
+.v2-warhacker-list-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.v2-builder-list-section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.v2-builder-list-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid rgba(134, 147, 150, 0.2);
+  padding-bottom: 4px;
+}
+
+.v2-list-section-title {
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.2em;
+  color: var(--v2-on-surface-variant);
+  text-transform: uppercase;
+}
+
+.v2-list-section-meta {
+  font-size: 10px;
+  color: rgba(79, 215, 240, 0.6);
+}
+
+.v2-warhacker-unit-card-v2 {
+  background-color: var(--v2-surface-container);
+  position: relative;
+  border-top-width: 1px;
+  border-top-style: solid;
+}
+
+.border-primary-dim { border-top-color: rgba(79, 215, 240, 0.2); }
+
+.v2-card-flex { display: flex; }
+
+.v2-card-portrait-box {
+  width: 80px;
+  height: 96px;
+  background-color: var(--v2-surface-variant);
+  flex-shrink: 0;
+  position: relative;
+  overflow: hidden;
+}
+
+.v2-img-unit { width: 100%; height: 100%; object-fit: cover; }
+.grayscale-80 { filter: grayscale(1); opacity: 0.8; }
+
+.v2-card-details {
+  flex: 1;
+  padding: 16px;
+  position: relative;
+  box-sizing: border-box;
+}
+
+.v2-pts-overlay {
+  position: absolute;
+  top: 0;
+  right: 0;
+  background-color: var(--v2-primary-container);
+  color: var(--v2-on-primary-container);
+  padding: 4px 12px;
+  font-family: var(--v2-font-headline);
+  font-weight: 700;
+  font-size: 12px;
+}
+
+.v2-unit-card-title {
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  color: var(--v2-primary);
+  text-transform: uppercase;
+}
+
+.v2-unit-card-subtitle {
+  font-size: 10px;
+  color: var(--v2-on-surface-variant);
+  text-transform: uppercase;
+  margin-top: 4px;
+  letter-spacing: -0.025em;
+}
+
+.v2-unit-stats-grid {
+  display: flex;
+  gap: 16px;
+  margin-top: 12px;
+}
+
+.v2-unit-stat-item { text-align: center; }
+.v2-stat-label { font-size: 8px; color: var(--v2-on-surface-variant); text-transform: uppercase; }
+.v2-stat-val { font-size: 12px; font-weight: 700; }
+
+.v2-warhacker-jack-expanded {
+  background-color: var(--v2-surface-container-high);
+  border-top: 2px solid var(--v2-tertiary);
+}
+
+.v2-jack-header {
+  padding: 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.v2-jack-identity { display: flex; align-items: center; gap: 12px; }
+
+.text-tertiary { color: var(--v2-tertiary); }
+
+.v2-jack-name { font-size: 14px; font-weight: 700; color: var(--v2-on-surface); text-transform: uppercase; }
+.v2-jack-type { font-size: 9px; color: var(--v2-on-surface-variant); text-transform: uppercase; }
+
+.v2-jack-pts-row { display: flex; align-items: center; gap: 16px; }
+.v2-jack-pts { font-size: 14px; font-weight: 700; color: var(--v2-tertiary); }
+.v2-expand-icon { color: var(--v2-on-surface-variant); }
+
+.v2-jack-details {
+  padding: 0 16px 16px;
+  border-top: 1px solid rgba(134, 147, 150, 0.1);
+  padding-top: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.v2-jack-stats-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 8px; }
+
+.v2-jack-stat-box {
+  background-color: var(--v2-surface-container-lowest);
+  padding: 8px;
+  text-align: center;
+  border-bottom: 1px solid rgba(0, 218, 243, 0.3);
+}
+
+.v2-jack-stat-label { font-size: 8px; color: var(--v2-on-surface-variant); text-transform: uppercase; }
+.v2-jack-stat-val { font-size: 14px; font-weight: 700; }
+
+.v2-weapon-section-label {
+  font-size: 10px;
+  color: var(--v2-tertiary);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin-bottom: 4px;
+}
+
+.v2-weapon-row {
+  background-color: var(--v2-surface-container);
+  padding: 8px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.v2-weapon-name { font-size: 11px; font-weight: 500; text-transform: uppercase; }
+.v2-weapon-pow { font-size: 10px; color: var(--v2-on-surface-variant); }
+
+.v2-warhacker-unit-item-v2 {
+  background-color: var(--v2-surface-container);
+  border-top: 1px solid rgba(134, 147, 150, 0.2);
+  padding: 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.v2-collapsed-icon { color: var(--v2-on-surface-variant); }
+.v2-jack-pts-collapsed { font-size: 14px; font-weight: 700; color: var(--v2-on-surface-variant); }
+
+.border-top-soft { border-top: 1px solid rgba(134, 147, 150, 0.2); }
+.p-bottom-48 { padding-bottom: 48px; }
+
+.v2-warhacker-fab-add {
+  position: fixed;
+  bottom: 96px;
+  right: 24px;
+  width: 56px;
+  height: 56px;
+  background-color: var(--v2-primary);
+  color: var(--v2-on-primary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0;
+  border: none;
+  box-shadow: 0 0 20px rgba(79, 215, 240, 0.4);
+  z-index: 50;
+  transition: all 0.3s ease;
+  cursor: pointer;
+}
+
+.v2-fab-icon { font-size: 36px; }
+
+.v2-warhacker-fab-add:hover {
+  box-shadow: 0 0 30px rgba(79, 215, 240, 0.6);
+  transform: scale(1.05);
+}
+
+.v2-warhacker-fab-add:active { transform: scale(0.9); }
+</style>

--- a/src/views/v2/warhacker/FactionsPage.vue
+++ b/src/views/v2/warhacker/FactionsPage.vue
@@ -1,0 +1,96 @@
+<template>
+  <div class="v2-warhacker-factions">
+    <!-- Header Section -->
+    <section class="v2-factions-header">
+      <div class="v2-header-accent-row">
+        <div class="v2-accent-bar"></div>
+        <span class="font-label v2-header-status">System Status: Ready</span>
+      </div>
+      <h1 class="font-headline v2-factions-title">SELECT_FACTION</h1>
+      <p class="font-body v2-factions-desc">Initialize neural link with desired legion. Strategic protocols will be calibrated based on origin.</p>
+    </section>
+
+    <!-- Faction Scroll List -->
+    <div class="v2-factions-list">
+      <article v-for="faction in factions" :key="faction.name" class="v2-faction-article">
+        <div class="v2-faction-marker"></div>
+        <div class="v2-faction-card-v2 glass-panel">
+          <div class="v2-faction-hero">
+            <img class="v2-faction-img grayscale-luminosity" :src="faction.image" :alt="faction.name"/>
+            <div class="v2-faction-gradient"></div>
+            <div class="v2-faction-origin">
+              ORIGIN: {{ faction.origin }}
+            </div>
+          </div>
+          <div class="v2-faction-details">
+            <div class="v2-faction-name-row">
+              <h2 class="font-headline v2-faction-name-title">{{ faction.name }}</h2>
+              <span class="material-symbols-outlined v2-faction-icon-v2">{{ faction.icon }}</span>
+            </div>
+            <p class="font-body v2-faction-bio">{{ faction.description }}</p>
+            <button class="v2-button v2-button-primary v2-faction-btn-v2">
+              <span>Initialize Command</span>
+              <span class="material-symbols-outlined v2-terminal-icon">terminal</span>
+            </button>
+          </div>
+        </div>
+      </article>
+    </div>
+  </div>
+</template>
+
+<script setup>
+const factions = [
+  { name: 'CRYX', icon: 'skull', origin: 'NIGHTMARE_EMPIRE', description: 'Master the necrotic arts. The Dragon Father\'s legions rise from the black waters to consume the mainland. High speed, high casualties, absolute victory.', image: 'https://lh3.googleusercontent.com/aida-public/AB6AXuDfRRXuT8MusHklEpUoXZoNMMFwhvlaZfZwx9bmNzeia9Lg5i3G0dCCHI7SqOHS8_N9Rzo9jSG0sJSz5dzRZkd8d2cpJU5X3yrNXmPXkFQa0x9nzn8Ez5WVLZPu0fr_keU55lJI9bDDGk03lGNCo4QY-cphjilsxPQt4ZMLZd46DpbqQgfnCtNg1c7r4xj8Gtm9g-HvSFLGN89-R12pWkSHQSzbZtBCIeXI8351jvzroTd7oLo9ann8OL_24DD3eYzj8ONPOKAhUiax' },
+  { name: 'CYGNAR', icon: 'bolt', origin: 'CASPIA', description: 'The pinnacle of arcane science. Control the battlefield with precision firepower and storm-powered warjacks. Strike with the speed of lightning.', image: 'https://lh3.googleusercontent.com/aida-public/AB6AXuCWny6bm3R-zR9Ab2MzolTJjeMO-sLa6ZjRyjDwesSi8SqExrWw_N0ptI-4rzG8D0NnltKMNTOu9M5HZsouJ7NvRiiv2gx10QK3tnv23iLv0u1c5PArdSU9cGzhe-YSA99JdWHt_1kipy_K_HC4iDcJieJkQvqwo6C0knby5rVs_g9jXIo37SNL_N_qM6XUyx8A6D4yNwQmyYmK7OZC03KGWoMhHv3e-iYHWWeCegMmcApdFQ4QZcOt0s8Aw8faHNoOQFqZGYB3Bhx0' },
+  { name: 'KHADOR', icon: 'shield', origin: 'KORSK', description: 'Unbreakable resolve. Field massive, heavy-plated steamjacks and iron-willed infantry. Weather any storm and crush opposition under heavy treads.', image: 'https://lh3.googleusercontent.com/aida-public/AB6AXuAzBY3NtbZRzavcb-KiACa1ShXHzrLQgPI9_Z1CKlVS0fr9rcWa-YTi_DBG6A7hqDnZ73I2lhveAIpokZ8msaMWqbB2AAFvdF8CqbiVPpORcZ5Cv1ml2xZtkP1ZPVgirMQeoWPTROAn6Zij71Fdt1LN4M1Jwnn3dqW0cg009f5Aym1uhTodO5qacH9TuOFo9l6gyFz8ANicqmEotmZm5OuTIp2E67LPnLBKV3EtRdH14KPr2_7eaLCZ-CVngKVjlVdHbTJ0tLM9oCZY' }
+]
+</script>
+
+<style scoped>
+.v2-warhacker-factions { padding: 24px 16px; min-height: 100vh; }
+
+.v2-factions-header { margin-bottom: 32px; }
+
+.v2-header-accent-row { display: flex; align-items: center; gap: 8px; margin-bottom: 4px; }
+.v2-accent-bar { height: 4px; width: 32px; background-color: var(--v2-primary); }
+.v2-header-status { font-size: 12px; letter-spacing: 0.1em; color: var(--v2-primary); text-transform: uppercase; }
+
+.v2-factions-title { font-size: 30px; font-weight: 700; letter-spacing: -0.025em; color: var(--v2-on-surface); }
+
+.v2-factions-desc { font-size: 14px; color: var(--v2-on-surface-variant); max-width: 320px; margin-top: 8px; line-height: 1.5; }
+
+.v2-factions-list { display: flex; flex-direction: column; gap: 32px; padding-bottom: 48px; }
+
+.v2-faction-article { position: relative; border-left: 2px solid rgba(79, 215, 240, 0.3); }
+
+.v2-faction-marker { position: absolute; left: -2px; top: 0; height: 32px; width: 2px; background-color: var(--v2-primary); }
+
+.v2-faction-card-v2 { background-color: var(--v2-surface-container-low); overflow: hidden; }
+
+.v2-faction-hero { height: 192px; width: 100%; position: relative; }
+
+.v2-faction-img { width: 100%; height: 100%; object-fit: cover; opacity: 0.6; }
+.grayscale-luminosity { filter: grayscale(1); }
+
+.v2-faction-gradient { position: absolute; inset: 0; background: linear-gradient(to top, var(--v2-surface-container-low), transparent); }
+
+.v2-faction-origin {
+  position: absolute; top: 16px; right: 16px; background-color: var(--v2-primary-container); color: var(--v2-on-primary-container);
+  padding: 4px 12px; font-family: var(--v2-font-label); font-size: 10px; font-weight: 700; letter-spacing: 0.1em;
+}
+
+.v2-faction-details { padding: 20px; position: relative; }
+
+.v2-faction-name-row { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 12px; }
+
+.v2-faction-name-title { font-size: 24px; font-weight: 800; letter-spacing: 0.1em; color: var(--v2-primary); }
+
+.v2-faction-icon-v2 { color: rgba(79, 215, 240, 0.5); }
+
+.v2-faction-bio { font-size: 14px; color: var(--v2-on-surface-variant); line-height: 1.625; margin-bottom: 24px; }
+
+.v2-faction-btn-v2 { width: 100%; padding: 16px; gap: 8px; font-size: 14px; }
+
+.v2-terminal-icon { font-size: 14px; }
+</style>

--- a/src/views/v2/warhacker/HomePage.vue
+++ b/src/views/v2/warhacker/HomePage.vue
@@ -1,0 +1,664 @@
+<template>
+  <div class="v2-warhacker-home">
+    <!-- Hero HUD Section (Desktop: Screen 11, Mobile: Screen 12) -->
+    <section class="v2-warhacker-hero-container">
+      <div class="v2-warhacker-hero-main group">
+        <div class="v2-hero-glow"></div>
+        <div class="v2-hero-content">
+          <div class="v2-hero-status-row">
+            <span class="v2-hero-tag">Sector Alpha-9</span>
+            <span class="v2-mobile-status">CONNECTION STATUS: SECURE</span>
+          </div>
+          <h1 class="font-headline v2-hero-title">
+            COMMAND <span class="v2-text-glow">LINK</span> <br class="hidden-mobile"/>ESTABLISHED
+          </h1>
+          <p class="v2-hero-desc">
+            Deploy your tactical assets. Synchronize orbital support. Override enemy network protocols. Your legion awaits the neural handshake.
+          </p>
+          <div class="v2-hero-actions">
+            <button class="v2-warhacker-btn-primary">
+              INITIALIZE NEURAL LINK
+              <span class="material-symbols-outlined hidden-mobile">arrow_forward</span>
+            </button>
+            <button class="v2-warhacker-btn-outline">
+              SYSTEM DIAGNOSTICS
+              <span class="material-symbols-outlined opacity-50">analytics</span>
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Terminal / Status Panel (Desktop Only) -->
+      <div class="v2-warhacker-terminal hidden-mobile">
+        <div class="terminal-header">
+          <h3 class="font-headline">Terminal Status</h3>
+          <div class="terminal-dots">
+            <div class="dot bg-error"></div>
+            <div class="dot bg-secondary"></div>
+            <div class="dot bg-primary"></div>
+          </div>
+        </div>
+        <div class="terminal-body font-mono">
+          <p class="animate-pulse">&gt; UPLINK SECURED...</p>
+          <p>&gt; AUTHENTICATING COMMANDER_01...</p>
+          <p class="text-secondary">&gt; WARNING: VOID INTERFERENCE DETECTED</p>
+          <p>&gt; SCRYING FACTION DATA: 100%</p>
+          <p>&gt; ASSET RECOVERY: COMPLETE</p>
+          <p>&gt; LOCAL TIME: 04:22:19_ZULU</p>
+          <p>&gt; ENCRYPTION: AES-2048-WAR</p>
+          <p class="text-logs-header">// RECENT LOGS</p>
+          <p class="text-log-entry">04:21 - List 'Cinder-Fall' updated</p>
+          <p class="text-log-entry">04:19 - New mercenary pack added</p>
+          <p class="text-log-entry">04:15 - Deployment zone identified</p>
+        </div>
+        <div class="terminal-footer">
+          <span>WARDICE.APP CORE v4.0.2</span>
+          <span class="material-symbols-outlined v2-footer-icon">bolt</span>
+        </div>
+      </div>
+    </section>
+
+    <!-- Navigation Bento Grid / Tactical Modules -->
+    <section class="v2-bento-grid">
+      <div v-for="mod in modules" :key="mod.title" class="v2-bento-item group">
+        <img class="v2-bento-bg" :src="mod.image" :alt="mod.title"/>
+        <div class="v2-bento-overlay"></div>
+        <div class="v2-bento-content">
+          <span class="material-symbols-outlined v2-bento-icon" :style="{ color: mod.color }">{{ mod.icon }}</span>
+          <h3 class="font-headline">{{ mod.title }}</h3>
+          <p>{{ mod.description }}</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Active Army Lists (Desktop: Screen 11) / Recent Lists (Mobile: Screen 12) -->
+    <section class="v2-deployment-section">
+      <div class="v2-deployment-header">
+        <div>
+          <h2 class="font-headline v2-deployment-title">Deployment Lists</h2>
+          <p class="font-headline v2-deployment-subtitle hidden-mobile">Active Neural Configurations</p>
+        </div>
+        <button class="v2-view-all-btn">View All Files</button>
+      </div>
+
+      <div class="v2-lists-grid">
+        <div v-for="list in recentLists" :key="list.name" class="v2-list-card group">
+          <div class="list-pts-badge">{{ list.points }} PTS</div>
+          <div class="list-card-inner glass-panel">
+            <div class="list-image-box">
+              <img :src="list.image" :alt="list.name"/>
+            </div>
+            <div class="list-info">
+              <h4 class="font-headline">{{ list.name }}</h4>
+              <div class="list-tags">
+                <span class="text-secondary">{{ list.system }}</span>
+                <span class="text-outline">{{ list.faction }}</span>
+              </div>
+              <div class="list-meta">
+                <span class="flex-center gap-1"><span class="material-symbols-outlined v2-meta-icon">calendar_today</span> {{ list.lastAccess }}</span>
+                <span class="flex-center gap-1 hidden-mobile"><span class="material-symbols-outlined v2-meta-icon">format_list_bulleted</span> {{ list.units }} Units</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- FAB -->
+    <button class="v2-warhacker-fab">
+      <span class="material-symbols-outlined v2-fab-icon">add</span>
+    </button>
+
+    <!-- Visual Accents (HUD Elements) (Desktop Only) -->
+    <div class="v2-hud-accents hidden-mobile">
+      <div class="v2-hud-top-right">
+        SYSTEM_OVERRIDE: ACTIVE<br/>
+        LOCAL_TIME: 22:41:09<br/>
+        SIGNAL_STRENGTH: 98%<br/>
+        ENCRYPTION: AES-ARCANE-256
+      </div>
+      <div class="v2-hud-bottom-left">
+        <div class="v2-hud-line"></div>
+        <div class="v2-hud-text">Visualizing Strategic Projection</div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+const modules = [
+  {
+    title: 'Faction Intel',
+    icon: 'public',
+    color: '#4fd7f0',
+    description: 'Browse the Encyclopedia of War',
+    image: 'https://lh3.googleusercontent.com/aida-public/AB6AXuCG_gx_CpieMRyG0sGdVYdxKR19rFh7DZXml18u6zdbQbQdWcajB5n39pb7UA5RuKs8g6PA0JVE5FtdtbvNk5wdbSz70l0NJIUA3ECY1cQRW5Of20feqn3m6Ct40t6Rv7xW1KKHWHMueMFHcMNUHmTdKxaaTRJAdkfBmrJncA8I-8O0342hlsTpz-TChsdImDY3MXzFM8uVbgfG01RjwHhvMWEsPxf_Gr8hmM41ZJNBcviOe-HNIvloaQVF3A9G71o9-_m6t-zgqklY'
+  },
+  {
+    title: 'Active Engagement',
+    icon: 'swords',
+    color: '#ffb68b',
+    description: 'Join Current Live Game Session',
+    image: 'https://lh3.googleusercontent.com/aida-public/AB6AXuAOPMzMQvXJWZSUjky1GGso0XCzXBtTsGO-KqyS3yybcj11mD0x8Q809iJDQxuHojinap54-Fil6_5LFxWQAVHP5cCTLUmdehJnG0D0XlfHRWpb51w-FTRpmsO18huQ9vWXy5sRUqZVcGuhFdT0XBDhpu8l8DMb1CdjQrI1v1MrI2o1H8IRi1Q_9tDS4lrtKp9FfdTRYbZrcmE9R-oiW6l9R8Z5v6rajhZkbsOKp7vIOcwg90BP2bfgZ04Q54nGFxBwP3KGy1a-uc3F'
+  },
+  {
+    title: 'Unit Archives',
+    icon: 'database',
+    color: '#00daf3',
+    description: 'Manage Your Tactical Collection',
+    image: 'https://lh3.googleusercontent.com/aida-public/AB6AXuAc6zriupNzKLzIubMbCWiyr4Y_t3TlaNEBv3XU0N3YuRbrsZmXthKfioxWg8dwyy-Xx4j3eW0RKb_4Pj6P16aWZte3zvSTuqfzYxhC-FImT5Ww8ROOAr2J-JcDgQEA6-JOLyPfYKl32y2uEcp9z-2DsZDeUAx3pGiEZDYNszLJY1WcUt3PeJbnqfNXR7nLXBYlmrJG-eaXu7pRla8IuNU2FmHNmHnFlSI66X47kqUzTCNwfZ1c2nzqaHyXJnXyXKO4iEAagYeEKnN4'
+  }
+]
+
+const recentLists = [
+  {
+    name: 'Iron Aegis Legion',
+    points: 75,
+    lastAccess: '2 Days Ago',
+    system: 'Warmachine',
+    faction: 'Khador',
+    units: 14,
+    image: 'https://lh3.googleusercontent.com/aida-public/AB6AXuC3D-L9l7N8thHmdLezosBwmgYWasT7PM4LCEVy3KUE1aOO0Wvf3DFrKZd_sSHdEIA0t303p__GQoZ5AlxSXWjHTJgLl-OiOuCqz1rcotyslLoWRzN30QVyvYhZrgaRR1X-ZWn8nokJ7p9EDyJaZK6rg1yslcxg8MlcqN04wOHuv2TIrPzlhET_Wyx_fjYzGSwZ4BtB0XQ6vTxLLtA4pIKw1--wbxX-uK2D-QsBFRzqLP4k6PfKstTThMwJWpkE1VvZoJ9-a4tvZL1e'
+  },
+  {
+    name: 'Shadow Protocol',
+    points: 100,
+    lastAccess: '5 Hours Ago',
+    system: 'Hordes',
+    faction: 'Circle Orboros',
+    units: 9,
+    image: 'https://lh3.googleusercontent.com/aida-public/AB6AXuDYloeRmij8pS8kpF7_h2bDZegU8b_Dtmkivsx-PrS5ig4LCXlMI0lcWzN_mv068BawKcerrjJJWkrT7ZouJj4UKgEjh6eB90ofTGsiBG-Rrgc3V46tRhrMTAhOQFba0F2wij3pZl5OPErye-fFwF7BzNE_5Np-fHSXTCv7Y3ekMoid3rEVAuDZyeWw2lEGi1Y8bcXFYFOXIp9o8HaCk5h4FDVfZpQZJISlsyFu9_DZ4mERYE5UO6m5eDy81_fhWqav4yD3nnXec6mM'
+  }
+]
+</script>
+
+<style scoped>
+.v2-warhacker-home {
+  padding: 32px 16px;
+  box-sizing: border-box;
+}
+
+@media (min-width: 1024px) {
+  .v2-warhacker-home {
+    padding-left: 32px;
+    padding-right: 32px;
+  }
+}
+
+.v2-warhacker-hero-container {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 24px;
+  margin-bottom: 48px;
+}
+
+@media (min-width: 1024px) {
+  .v2-warhacker-hero-container {
+    grid-template-columns: repeat(12, 1fr);
+  }
+}
+
+.v2-warhacker-hero-main {
+  position: relative;
+  overflow: hidden;
+  min-height: 320px;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  border-left: 4px solid var(--v2-primary);
+  background-color: var(--v2-surface-container-low);
+}
+
+@media (min-width: 1024px) {
+  .v2-warhacker-hero-main {
+    grid-column: span 8;
+    min-height: 400px;
+  }
+}
+
+.v2-hero-glow {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to top right, rgba(79, 215, 240, 0.2), transparent);
+  opacity: 0.5;
+  transition: opacity 0.3s ease;
+}
+
+.v2-warhacker-hero-main:hover .v2-hero-glow {
+  opacity: 0.7;
+}
+
+.v2-hero-content {
+  position: relative;
+  z-index: 10;
+  padding: 32px;
+}
+
+.v2-hero-status-row { margin-bottom: 16px; }
+
+.v2-hero-tag {
+  background-color: rgba(79, 215, 240, 0.2);
+  color: var(--v2-primary);
+  padding: 4px 12px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  border: 1px solid rgba(79, 215, 240, 0.3);
+}
+
+.v2-mobile-status {
+  display: block;
+  margin-top: 8px;
+  font-size: 10px;
+  color: var(--v2-primary);
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  opacity: 0.7;
+}
+
+@media (min-width: 768px) {
+  .v2-mobile-status { display: none; }
+  .v2-hero-tag { display: inline-block; }
+}
+
+@media (max-width: 767px) {
+  .v2-hero-tag { display: none; }
+}
+
+.v2-hero-title {
+  font-size: 36px;
+  font-weight: 900;
+  color: var(--v2-on-surface);
+  letter-spacing: -0.05em;
+  line-height: 1;
+  margin-bottom: 24px;
+}
+
+@media (min-width: 768px) {
+  .v2-hero-title { font-size: 72px; }
+}
+
+.v2-text-glow {
+  color: var(--v2-primary);
+  text-shadow: 0 0 12px rgba(79, 215, 240, 0.6);
+}
+
+.v2-hero-desc {
+  color: var(--v2-on-surface-variant);
+  max-width: 512px;
+  font-size: 14px;
+  margin-bottom: 32px;
+  line-height: 1.625;
+  font-weight: 300;
+}
+
+@media (min-width: 768px) {
+  .v2-hero-desc { font-size: 16px; }
+}
+
+.v2-hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.v2-warhacker-btn-primary {
+  background-color: var(--v2-primary);
+  color: var(--v2-on-primary);
+  font-family: var(--v2-font-headline);
+  font-weight: 900;
+  padding: 16px 40px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  border: none;
+  cursor: pointer;
+  box-shadow: 0 0 30px rgba(79, 215, 240, 0.2);
+  transition: all 0.3s ease;
+}
+
+.v2-warhacker-btn-primary:hover {
+  transform: scale(1.05);
+}
+
+.v2-warhacker-btn-outline {
+  background-color: transparent;
+  border: 1px solid var(--v2-outline-variant);
+  color: var(--v2-on-surface);
+  font-family: var(--v2-font-headline);
+  font-weight: 900;
+  padding: 16px 40px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.v2-warhacker-btn-outline:hover {
+  background-color: rgba(255, 255, 255, 0.05);
+}
+
+.v2-warhacker-terminal {
+  grid-column: span 4;
+  display: flex;
+  flex-direction: column;
+  background-color: rgba(5, 34, 47, 0.4);
+  backdrop-filter: blur(12px);
+  border-right: 4px solid rgba(255, 182, 139, 0.4);
+  padding: 24px;
+  box-sizing: border-box;
+}
+
+.terminal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 24px;
+  border-bottom: 1px solid var(--v2-outline-variant);
+  padding-bottom: 8px;
+}
+
+.terminal-header h3 {
+  font-size: 12px;
+  font-weight: 900;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--v2-secondary);
+}
+
+.terminal-dots { display: flex; gap: 4px; }
+.terminal-dots .dot { width: 8px; height: 8px; }
+.bg-error { background-color: var(--v2-error); }
+.bg-secondary { background-color: var(--v2-secondary); }
+.bg-primary { background-color: var(--v2-primary); }
+
+.terminal-body {
+  flex-grow: 1;
+  font-size: 11px;
+  line-height: 1.625;
+  color: rgba(79, 215, 240, 0.8);
+  overflow: hidden;
+  text-shadow: 0 0 8px rgba(79, 215, 240, 0.5);
+}
+
+.text-secondary { color: var(--v2-secondary); }
+.text-logs-header { color: var(--v2-outline); margin-top: 16px; }
+.text-log-entry { color: var(--v2-outline); opacity: 0.8; }
+
+.terminal-footer {
+  margin-top: 24px;
+  padding-top: 16px;
+  border-top: 1px solid var(--v2-outline-variant);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 10px;
+  color: var(--v2-outline);
+  letter-spacing: 0.1em;
+}
+
+.v2-footer-icon { font-size: 14px; color: var(--v2-primary); }
+
+.v2-bento-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 24px;
+  margin-bottom: 48px;
+}
+
+@media (min-width: 768px) {
+  .v2-bento-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.v2-bento-item {
+  position: relative;
+  aspect-ratio: 16/9;
+  overflow: hidden;
+  border: 1px solid var(--v2-outline-variant);
+  cursor: pointer;
+  transition: border-color 0.3s ease;
+}
+
+@media (min-width: 768px) {
+  .v2-bento-item { height: 256px; aspect-ratio: auto; }
+}
+
+.v2-bento-item:hover {
+  border-color: var(--v2-primary);
+}
+
+.v2-bento-bg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  opacity: 0.4;
+  transition: transform 0.7s ease;
+}
+
+.v2-bento-item:hover .v2-bento-bg {
+  transform: scale(1.1);
+}
+
+.v2-bento-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to top, var(--v2-background), transparent);
+}
+
+.v2-bento-content {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  padding: 24px;
+}
+
+.v2-bento-icon { margin-bottom: 8px; }
+
+.v2-bento-content h3 {
+  font-size: 20px;
+  font-weight: 700;
+  text-transform: uppercase;
+  margin-bottom: 4px;
+}
+
+.v2-bento-content p {
+  font-size: 12px;
+  color: var(--v2-on-surface-variant);
+  font-weight: 500;
+}
+
+.v2-deployment-section { margin-top: 64px; }
+
+.v2-deployment-header { display: flex; justify-content: space-between; align-items: flex-end; margin-bottom: 32px; }
+
+.v2-deployment-title { font-size: 24px; font-weight: 900; letter-spacing: 0.1em; text-transform: uppercase; }
+
+.v2-deployment-subtitle { color: var(--v2-outline); font-size: 10px; letter-spacing: 0.3em; text-transform: uppercase; }
+
+.v2-view-all-btn {
+  color: var(--v2-primary);
+  font-family: var(--v2-font-headline);
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+}
+
+.v2-view-all-btn:hover { text-decoration: underline; }
+
+.v2-lists-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 32px;
+}
+
+@media (min-width: 1024px) {
+  .v2-lists-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.v2-list-card {
+  position: relative;
+}
+
+.list-pts-badge {
+  position: absolute;
+  top: -12px;
+  right: 16px;
+  background-color: var(--v2-primary);
+  color: var(--v2-on-primary);
+  font-family: var(--v2-font-headline);
+  font-weight: 900;
+  padding: 8px 16px;
+  font-size: 20px;
+  z-index: 10;
+}
+
+.list-card-inner {
+  padding: 32px;
+  display: flex;
+  gap: 24px;
+  background-color: rgba(5, 34, 47, 0.4);
+  transition: background-color 0.3s ease;
+}
+
+.v2-list-card:hover .list-card-inner {
+  background-color: var(--v2-surface-container-high);
+}
+
+.list-image-box {
+  width: 128px;
+  height: 128px;
+  background-color: var(--v2-surface-container-highest);
+  border: 1px solid var(--v2-outline-variant);
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.list-image-box img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: grayscale(1) brightness(0.75);
+  transition: all 0.3s ease;
+}
+
+.v2-list-card:hover .list-image-box img {
+  filter: grayscale(0);
+}
+
+.list-info {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.list-info h4 {
+  font-size: 24px;
+  font-weight: 700;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+  transition: color 0.3s ease;
+}
+
+.v2-list-card:hover .list-info h4 {
+  color: var(--v2-primary);
+}
+
+.list-tags {
+  display: flex; gap: 8px; font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.1em; margin-bottom: 16px;
+}
+
+.list-meta {
+  display: flex; gap: 24px; font-size: 11px; font-weight: 700; color: var(--v2-outline); text-transform: uppercase; letter-spacing: 0.1em;
+}
+
+.v2-meta-icon { font-size: 12px; }
+
+.v2-warhacker-fab {
+  position: fixed;
+  bottom: 96px;
+  right: 24px;
+  width: 64px;
+  height: 64px;
+  background-color: var(--v2-primary);
+  color: var(--v2-on-primary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0;
+  border: none;
+  box-shadow: 0 0 20px rgba(79, 215, 240, 0.4);
+  cursor: pointer;
+  z-index: 40;
+  transition: all 0.3s ease;
+}
+
+@media (min-width: 768px) {
+  .v2-warhacker-fab { bottom: 32px; right: 32px; }
+}
+
+.v2-fab-icon { font-size: 30px; }
+
+.v2-warhacker-fab:hover {
+  transform: scale(1.05);
+}
+
+.v2-warhacker-fab:active {
+  transform: scale(0.9);
+}
+
+.v2-hud-accents {
+  pointer-events: none;
+  opacity: 0.2;
+}
+
+.v2-hud-top-right {
+  position: fixed;
+  top: 80px;
+  right: 16px;
+  font-family: monospace;
+  font-size: 8px;
+  color: var(--v2-primary);
+  line-height: 1.2;
+  text-align: right;
+  z-index: 60;
+}
+
+.v2-hud-bottom-left {
+  position: fixed;
+  bottom: 32px;
+  left: 272px; /* Layout aside is 256px + some margin */
+  z-index: 60;
+  opacity: 0.5;
+}
+
+.v2-hud-line {
+  width: 192px;
+  height: 1px;
+  background: linear-gradient(to right, var(--v2-primary), transparent);
+}
+
+.v2-hud-text {
+  margin-top: 4px;
+  font-size: 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--v2-primary);
+}
+
+.flex-center { display: flex; align-items: center; }
+.gap-1 { gap: 4px; }
+
+@media (max-width: 767px) {
+  .hidden-mobile { display: none !important; }
+}
+</style>

--- a/src/views/v2/warhacker/IntelPage.vue
+++ b/src/views/v2/warhacker/IntelPage.vue
@@ -1,0 +1,336 @@
+<template>
+  <div class="v2-warhacker-intel">
+    <!-- Tactical Header: Timer & VPs -->
+    <section class="v2-intel-header">
+      <div class="intel-stat-v2 border-primary-dim">
+        <span class="font-label v2-intel-label">Player 01</span>
+        <span class="font-headline v2-intel-val-primary">14 <span class="v2-intel-val-meta">VP</span></span>
+      </div>
+      <div class="intel-stat-v2 active-timer border-primary">
+        <span class="font-label v2-intel-label-primary">Turn Timer</span>
+        <span class="font-headline v2-intel-val-on-surface">60:00</span>
+      </div>
+      <div class="intel-stat-v2 border-secondary-dim text-right">
+        <span class="font-label v2-intel-label">Enemy 02</span>
+        <span class="font-headline v2-intel-val-secondary">09 <span class="v2-intel-val-meta">VP</span></span>
+      </div>
+    </section>
+
+    <!-- Scenario Map Trigger -->
+    <button class="v2-map-trigger">
+      <div class="v2-map-trigger-info">
+        <div class="radar-box">
+          <span class="material-symbols-outlined v2-radar-icon">map</span>
+          <div class="radar-pulse"></div>
+        </div>
+        <div>
+          <span class="font-label v2-radar-tag">Engagement Sector</span>
+          <span class="font-headline v2-radar-title">Scenario_Map_04</span>
+        </div>
+      </div>
+      <span class="material-symbols-outlined v2-radar-arrow">chevron_right</span>
+    </button>
+
+    <!-- Tab Switcher -->
+    <div class="v2-tab-switcher">
+      <button class="tab-btn active">MY ARMY</button>
+      <button class="tab-btn">OPPONENT</button>
+    </div>
+
+    <!-- Unit List -->
+    <div class="v2-intel-unit-list">
+      <div v-for="unit in units" :key="unit.name" class="v2-intel-unit-card" :class="{ 'border-command': unit.type === 'command' }">
+        <div class="card-header-v2" :class="{ 'bg-command': unit.type === 'command' }">
+          <div class="v2-unit-header-flex">
+            <div class="intel-unit-portrait" :class="unit.type === 'command' ? 'bg-primary-soft' : 'bg-variant-soft'">
+              <img v-if="unit.image" :alt="unit.name" class="v2-unit-img" :src="unit.image"/>
+              <span v-else class="material-symbols-outlined v2-unit-icon">{{ unit.icon }}</span>
+            </div>
+            <div>
+              <span class="font-headline v2-unit-card-name">{{ unit.name }}</span>
+              <span class="font-label v2-unit-card-type" :style="{ color: unit.type === 'command' ? '#4fd7f0' : (unit.subTypeColorValue || 'rgba(79, 215, 240, 0.7)') }">{{ unit.subType }}</span>
+            </div>
+          </div>
+          <div class="intel-pts-badge" :class="unit.type === 'command' ? 'badge-command' : 'badge-normal'">
+            {{ unit.points }}
+          </div>
+        </div>
+        <div v-if="unit.type !== 'command'" class="card-body-v2">
+          <div class="v2-health-section">
+            <div class="v2-health-labels">
+              <span class="v2-health-tag">{{ unit.healthLabel }}</span>
+              <span class="v2-health-val" :style="{ color: unit.healthColorValue || 'var(--v2-primary)' }">{{ unit.health }}%</span>
+            </div>
+            <div class="v2-health-bar-container">
+              <div class="v2-health-bar" :style="{ width: unit.health + '%', backgroundColor: unit.healthBgValue || 'var(--v2-primary)' }"></div>
+            </div>
+            <div v-if="unit.grid" class="v2-damage-grid-row">
+              <div v-for="n in 6" :key="n" class="v2-damage-dot" :style="{ backgroundColor: n <= unit.gridFilled ? (unit.healthBgValue || 'var(--v2-primary)') : 'var(--v2-surface-container-highest)' }"></div>
+            </div>
+          </div>
+          <div class="v2-intel-stats">
+            <div v-for="(val, stat) in unit.stats" :key="stat" class="v2-intel-stat-item">
+              <span class="font-label v2-intel-stat-label">{{ stat }}</span>
+              <span class="font-headline v2-intel-stat-val">{{ val }}</span>
+            </div>
+          </div>
+        </div>
+        <div v-else class="card-footer-v2">
+          <div class="v2-buff-row">
+            <span class="material-symbols-outlined v2-buff-icon">bolt</span>
+            <span class="font-label v2-buff-label">Active Buff: {{ unit.buff }}</span>
+          </div>
+          <p class="v2-buff-desc">{{ unit.buffDesc }}</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- FAB Ghost Element -->
+    <div class="v2-intel-fab-container">
+      <button class="v2-intel-fab">
+        <span class="material-symbols-outlined v2-fab-icon">add</span>
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+const units = [
+  { name: 'Razorwing_Strider', subType: 'Fast Attack • Elite', points: '125 PTS', health: 85, healthLabel: 'Structural Integrity', healthColorValue: '#4fd7f0', healthBgValue: '#4fd7f0', grid: true, gridFilled: 4, stats: { SPD: '07', ARM: '19', DEF: '14' }, image: 'https://lh3.googleusercontent.com/aida-public/AB6AXuDuzJpB24pAKt53dq0WZcyC2g74UNBYUaW5dmFHvxF7sPgoYr9bmq6kIkx0jy6b7xBRkXjVeBISFi7J8Ab8yUeQzt90k1gclLhA_Fmb9tEQTWeqw2b2PtBh8Hkr-lLoOhzpY4WwIBjMl0v0P8lpIfHm4TgKvsVSzenm7GSIgyubZqutxyOUymv2vaIqJYLS6QYh2czcuY1LYlmfMUpga7MweaHlP-r87V6466Yd48QwjTPKmw_W_sU332c5YlmUfllxjnOiQzlQfrKb' },
+  { name: 'Colossus_Chassis', subType: 'Heavy • Frontline', subTypeColorValue: 'rgba(255, 182, 139, 0.7)', points: '240 PTS', health: 30, healthLabel: 'Damage Taken', healthColorValue: '#ffb4ab', healthBgValue: '#ffb4ab', grid: true, gridFilled: 1, stats: { SPD: '04', ARM: '22', DEF: '10' }, image: 'https://lh3.googleusercontent.com/aida-public/AB6AXuD7YoWJZ5NawJFkbvxHCh0no5rSIenHbO52tN4SWpN2smivU_6H0OCrU2D3oqw6qSm90NBWB-SLVx0FdmBoye6avkMocOsiTD-XCSUpWuZXOdOsLewuFreQrhqt2o13whgfgNJGR2X4DsJm5dsBWGIvNWFiZexi_kwdo5nyl7WSzBpojIGOmZ3Cf56g6TxAn5JJiWRRbT_JQsKWATEGnOLaZe0H2d52EahMpRSLKuiUzjs8DtNOV8mXai9sTZxdRNUFQ0IJDqYk4VRB' },
+  { name: 'Commander_Vance', subType: 'Warhacker Alpha', type: 'command', icon: 'military_tech', points: 'COMMAND', buff: 'OVERDRIVE_PULSE', buffDesc: 'Units within 5" gain +2 Movement and Reroll failed Attack rolls.' }
+]
+</script>
+
+<style scoped>
+.v2-warhacker-intel {
+  padding: 16px; min-height: 100vh; box-sizing: border-box; padding-bottom: 96px;
+}
+
+.v2-intel-header {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 4px;
+  margin-bottom: 24px;
+}
+
+.intel-stat-v2 {
+  background-color: var(--v2-surface-container-low);
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  border-top-width: 1px;
+  border-top-style: solid;
+}
+
+.border-primary-dim { border-top-color: rgba(79, 215, 240, 0.2); }
+.border-primary { border-top-color: var(--v2-primary); }
+.border-secondary-dim { border-top-color: rgba(255, 182, 139, 0.2); }
+
+.v2-intel-label { font-size: 10px; letter-spacing: 0.1em; color: var(--v2-on-surface-variant); text-transform: uppercase; }
+.v2-intel-val-primary { font-size: 24px; font-weight: 700; color: var(--v2-primary); }
+.v2-intel-val-meta { font-size: 10px; opacity: 0.6; }
+
+.intel-stat-v2.active-timer {
+  background-color: rgba(79, 215, 240, 0.1);
+  border-top-width: 2px;
+}
+
+.v2-intel-label-primary { font-size: 10px; letter-spacing: 0.1em; color: var(--v2-primary); text-transform: uppercase; }
+.v2-intel-val-on-surface { font-size: 24px; font-weight: 700; color: var(--v2-on-surface); }
+
+.v2-intel-val-secondary { font-size: 24px; font-weight: 700; color: var(--v2-secondary); }
+
+.text-right { text-align: right; }
+
+.v2-map-trigger {
+  width: 100%;
+  background-color: var(--v2-surface-container);
+  border: 1px solid rgba(79, 215, 240, 0.1);
+  padding: 16px;
+  margin-bottom: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+}
+
+.v2-map-trigger:hover {
+  background-color: rgba(79, 215, 240, 0.05);
+}
+
+.v2-map-trigger-info { display: flex; align-items: center; gap: 12px; text-align: left; }
+
+.radar-box {
+  position: relative;
+  width: 48px;
+  height: 48px;
+  background-color: var(--v2-surface-container-highest);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.v2-radar-icon { color: var(--v2-primary); }
+
+.radar-pulse {
+  position: absolute;
+  inset: 0;
+  border: 1px solid rgba(79, 215, 240, 0.2);
+  animation: v2-pulse 2s infinite;
+}
+
+@keyframes v2-pulse {
+  0% { transform: scale(1); opacity: 1; }
+  100% { transform: scale(1.1); opacity: 0; }
+}
+
+.v2-radar-tag { display: block; font-size: 10px; color: rgba(79, 215, 240, 0.6); text-transform: uppercase; letter-spacing: -0.025em; }
+.v2-radar-title { display: block; font-size: 14px; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase; }
+.v2-radar-arrow { color: var(--v2-primary); }
+
+.v2-tab-switcher {
+  display: flex;
+  width: 100%;
+  margin-bottom: 24px;
+  background-color: var(--v2-surface-container-lowest);
+  padding: 4px;
+  box-sizing: border-box;
+}
+
+.tab-btn {
+  flex: 1;
+  padding: 12px 0;
+  text-align: center;
+  font-family: var(--v2-font-label);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  background: transparent;
+  color: var(--v2-on-surface-variant);
+  border: none;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  text-transform: uppercase;
+}
+
+.tab-btn.active {
+  background-color: var(--v2-primary);
+  color: var(--v2-on-primary);
+}
+
+.v2-intel-unit-list { display: flex; flex-direction: column; gap: 16px; }
+
+.v2-intel-unit-card {
+  background-color: var(--v2-surface-container);
+  overflow: hidden;
+  border-left: 2px solid transparent;
+}
+
+.v2-intel-unit-card.border-command { border-left-color: var(--v2-primary); }
+
+.card-header-v2 {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  padding: 16px;
+  background-color: var(--v2-surface-container-high);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.card-header-v2.bg-command {
+  background-color: rgba(79, 215, 240, 0.05);
+}
+
+.v2-unit-header-flex { display: flex; gap: 12px; }
+
+.intel-unit-portrait {
+  width: 40px;
+  height: 40px;
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.bg-primary-soft { background-color: rgba(79, 215, 240, 0.2); }
+.bg-variant-soft { background-color: rgba(30, 56, 69, 0.5); }
+
+.v2-unit-img { width: 100%; height: 100%; object-fit: cover; opacity: 0.8; }
+.v2-unit-icon { color: var(--v2-primary); scale: 1.25; }
+
+.v2-unit-card-name { display: block; font-size: 14px; font-weight: 700; letter-spacing: 0.05em; text-transform: uppercase; }
+.v2-unit-card-type { font-size: 10px; text-transform: uppercase; }
+
+.intel-pts-badge {
+  padding: 4px 8px;
+  border-width: 1px;
+  border-style: solid;
+  text-transform: uppercase;
+  font-family: var(--v2-font-label);
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.badge-command { background-color: rgba(79, 215, 240, 0.2); border-color: transparent; color: var(--v2-primary); }
+.badge-normal { background-color: rgba(0, 178, 202, 0.2); border-color: rgba(79, 215, 240, 0.3); color: var(--v2-primary); }
+
+.card-body-v2 {
+  padding: 16px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+.v2-health-section { display: flex; flex-direction: column; gap: 8px; }
+
+.v2-health-labels { display: flex; justify-content: space-between; align-items: center; font-size: 9px; text-transform: uppercase; }
+.v2-health-tag { color: var(--v2-on-surface-variant); }
+.v2-health-val { font-weight: 700; }
+
+.v2-health-bar-container { height: 4px; background-color: var(--v2-surface-container-highest); display: flex; }
+.v2-health-bar { height: 100%; }
+
+.v2-damage-grid-row { display: grid; grid-template-columns: repeat(6, 1fr); gap: 4px; margin-top: 4px; }
+.v2-damage-dot { height: 8px; }
+
+.v2-intel-stats { display: flex; justify-content: flex-end; gap: 12px; text-transform: uppercase; }
+.v2-intel-stat-item { text-align: center; }
+.v2-intel-stat-label { display: block; font-size: 8px; color: var(--v2-on-surface-variant); letter-spacing: -0.025em; }
+.v2-intel-stat-val { display: block; font-size: 18px; font-weight: 700; }
+
+.card-footer-v2 {
+  padding: 16px;
+  background-color: var(--v2-surface-container-low);
+}
+
+.v2-buff-row { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; }
+.v2-buff-icon { color: var(--v2-primary); font-size: 12px; }
+.v2-buff-label { font-size: 10px; color: var(--v2-primary); font-weight: 700; text-transform: uppercase; }
+.v2-buff-desc { font-size: 10px; color: var(--v2-on-surface-variant); line-height: 1.5; }
+
+.v2-intel-fab-container { position: fixed; bottom: 96px; right: 16px; display: flex; flex-direction: column; gap: 8px; z-index: 50; }
+
+.v2-intel-fab {
+  width: 56px;
+  height: 56px;
+  background-color: var(--v2-primary);
+  color: var(--v2-on-primary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  cursor: pointer;
+  box-shadow: 0 0 15px rgba(79, 215, 240, 0.4);
+  transition: transform 0.1s ease;
+}
+
+.v2-intel-fab:active {
+  transform: scale(0.95);
+}
+
+.v2-fab-icon { font-size: 24px; }
+</style>

--- a/src/views/v2/warhacker/UnitDetailPage.vue
+++ b/src/views/v2/warhacker/UnitDetailPage.vue
@@ -1,0 +1,305 @@
+<template>
+  <div class="v2-warhacker-unit-detail">
+    <!-- Hero Section -->
+    <section class="v2-hero-section group">
+      <div class="v2-hero-gradient"></div>
+      <img alt="Slayer Warjack" class="v2-hero-img grayscale-contrast" src="https://lh3.googleusercontent.com/aida-public/AB6AXuAeUgk7AtCYdiyUKgtFsMhgKKU9E_kII6U8x4J_BnMC_bjAPd1Cwa4Bq1whxtssYj2HuJufcXkk42dr8_oV9-NeqN-1irQBvj9b4Odm2AJcX9EF0KF5xRvuo514-jc8w7qGpBoXBWlMCnYQs4iS82jiNrMkCnFfsICI2Y793jhcflbH_sLd3fzEONeBYzCtHF-f_vWgGGGKoRyt0w-8QIkbo5B97dmTzaAP2FCoe9BP57xnMIL7BTHkIa5Vmu-r-ieXzTsqJ5EqISOU"/>
+      <div class="v2-hero-info">
+        <h1 class="font-headline v2-hero-title">SLAYER_V4</h1>
+        <div class="v2-hero-tags">
+          <span class="v2-hero-tag tag-primary">HEAVY_CHASSIS</span>
+          <span class="v2-hero-tag tag-secondary">EXPERIMENTAL</span>
+        </div>
+      </div>
+      <div class="v2-hero-pts-box">
+        <span class="font-headline v2-hero-pts">16 PT</span>
+      </div>
+    </section>
+
+    <!-- Stats Grid -->
+    <section class="v2-stats-readout">
+      <div v-for="(val, label) in stats" :key="label" class="v2-stat-card-v2" :class="{ 'border-secondary': label === 'THR' }">
+        <span class="v2-stat-card-label">{{ label }}</span>
+        <span class="font-headline v2-stat-card-val" :class="{ 'text-secondary': label === 'THR' }">{{ val }}</span>
+      </div>
+    </section>
+
+    <!-- Critical Status: Damage Grid -->
+    <section class="v2-damage-grid-section">
+      <div class="v2-section-header-v2">
+        <h3 class="font-headline v2-section-title-v2">
+          <span class="material-symbols-outlined v2-section-icon-v2">monitor_heart</span>
+          Hull_Integrity_Grid
+        </h3>
+        <span class="v2-warning-pulse">SYSTEM_WARNING</span>
+      </div>
+      <div class="v2-hull-grid-container">
+        <!-- Row 1 -->
+        <div class="v2-hull-row">
+          <div class="v2-hull-cell cell-ok"></div>
+          <div class="v2-hull-cell cell-ok"></div>
+        </div>
+        <!-- Row 2 -->
+        <div class="v2-hull-row">
+          <div class="v2-hull-cell cell-ok"></div>
+          <div class="v2-hull-cell cell-empty"><span class="material-symbols-outlined v2-cell-icon">close</span></div>
+          <div class="v2-hull-cell cell-ok"></div>
+          <div class="v2-hull-cell cell-ok"></div>
+        </div>
+        <!-- Row 3 -->
+        <div class="v2-hull-row">
+          <div v-for="cell in hullRow3" :key="cell.label" class="v2-hull-stack">
+            <div class="v2-hull-cell cell-ok"></div>
+            <span class="font-label v2-hull-label">{{ cell.label }}</span>
+          </div>
+        </div>
+      </div>
+      <!-- Grid Underglow -->
+      <div class="v2-grid-underglow"></div>
+    </section>
+
+    <!-- Combat Directives & Weapons -->
+    <section class="v2-combat-systems">
+      <div>
+        <h4 class="font-label v2-system-group-label">Tactical_Directives</h4>
+        <div class="v2-directives-grid">
+          <button class="v2-directive-btn btn-primary-v2">
+            OVERDRIVE_MODE
+            <span class="material-symbols-outlined v2-directive-icon">bolt</span>
+          </button>
+          <button class="v2-directive-btn btn-outline-v2">
+            GUARD_STANCE
+            <span class="material-symbols-outlined v2-directive-icon">shield</span>
+          </button>
+        </div>
+      </div>
+      <div>
+        <h4 class="font-label v2-system-group-label">Weapon_Systems</h4>
+        <div class="v2-weapons-stack">
+          <div v-for="weapon in weapons" :key="weapon.name" class="v2-weapon-item-v2" :class="{ 'border-offline': weapon.offline }">
+            <div>
+              <span class="font-headline v2-weapon-name-v2" :class="weapon.offline ? 'text-secondary' : 'text-primary'">{{ weapon.name }}</span>
+              <span class="font-body v2-weapon-stats-v2">{{ weapon.stats }}</span>
+            </div>
+            <div class="v2-weapon-status-box">
+              <span v-if="weapon.offline" class="font-label v2-offline-tag">OFFLINE</span>
+              <span v-else class="material-symbols-outlined v2-system-icon">settings_input_component</span>
+              <div class="v2-status-dot" :class="weapon.offline ? 'bg-secondary-dim' : 'bg-primary'"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Ability Chips -->
+    <section class="v2-abilities-section">
+      <h4 class="font-label v2-system-group-label">Special_Abilities</h4>
+      <div class="v2-abilities-wrap">
+        <span v-for="ability in abilities" :key="ability.name" class="v2-ability-chip" :class="ability.type">
+          {{ ability.name }}
+        </span>
+      </div>
+    </section>
+  </div>
+</template>
+
+<script setup>
+const stats = { SPD: '06', STR: '12', MAT: '07', DEF: '13', ARM: '17', CMD: '--', THR: '09', VOL: '05' }
+const hullRow3 = [{ label: 'L' }, { label: 'M' }, { label: 'C' }, { label: 'C' }, { label: 'M' }, { label: 'R' }]
+const weapons = [
+  { name: 'Death_Claw (L)', stats: 'RNG: 1 | POW: 16 | P+S: 28' },
+  { name: 'Death_Claw (R)', stats: 'RNG: 1 | POW: 16 | P+S: 28' },
+  { name: 'Hellfire_Cannon', stats: 'RNG: 10 | ROF: 1 | AOE: 3', offline: true }
+]
+const abilities = [
+  { name: 'STEALTH_CIRCUIT', type: 'primary' },
+  { name: 'VOID_STRIKE', type: 'primary' },
+  { name: 'EXPERIMENTAL_DRIVE', type: 'secondary' },
+  { name: 'GHOST_WALKER', type: 'primary' }
+]
+</script>
+
+<style scoped>
+.v2-warhacker-unit-detail {
+  padding-bottom: 96px;
+  flex-grow: 1;
+}
+
+.v2-hero-section {
+  margin-top: 16px;
+  position: relative;
+  height: 256px;
+  width: 100%;
+  background-color: var(--v2-surface-container-low);
+  overflow: hidden;
+}
+
+.v2-hero-gradient {
+  position: absolute;
+  inset: 0;
+  z-index: 10;
+  background: linear-gradient(to top, var(--v2-background), transparent, rgba(79, 215, 240, 0.1));
+}
+
+.v2-hero-img {
+  width: 100%; height: 100%; object-fit: cover;
+}
+
+.grayscale-contrast {
+  filter: grayscale(1) brightness(0.75) contrast(1.25);
+}
+
+.v2-hero-info {
+  position: absolute;
+  bottom: 16px;
+  left: 16px;
+  z-index: 20;
+}
+
+.v2-hero-title {
+  font-size: 30px;
+  font-weight: 900;
+  color: var(--v2-primary);
+  letter-spacing: -0.05em;
+  text-transform: uppercase;
+}
+
+.v2-hero-tags { display: flex; gap: 8px; margin-top: 4px; }
+
+.v2-hero-tag {
+  font-family: var(--v2-font-label);
+  font-size: 10px;
+  padding: 2px 8px;
+  border-width: 1px;
+  border-style: solid;
+}
+
+.tag-primary { background-color: rgba(79, 215, 240, 0.2); color: var(--v2-primary); border-color: rgba(79, 215, 240, 0.3); }
+.tag-secondary { background-color: rgba(255, 127, 28, 0.2); color: var(--v2-secondary); border-color: rgba(255, 127, 28, 0.3); }
+
+.v2-hero-pts-box {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  z-index: 20;
+  background-color: var(--v2-primary-container);
+  padding: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.v2-hero-pts { font-weight: 900; text-transform: uppercase; font-size: 20px; letter-spacing: -0.025em; color: var(--v2-on-primary-container); }
+
+.v2-stats-readout {
+  margin-top: 24px;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+  padding: 0 16px;
+}
+
+.v2-stat-card-v2 {
+  background-color: var(--v2-surface-container);
+  padding: 12px;
+  border-top-width: 2px;
+  border-top-style: solid;
+  border-top-color: rgba(79, 215, 240, 0.4);
+}
+
+.v2-stat-card-v2.border-secondary { border-top-color: rgba(255, 182, 139, 0.4); }
+
+.v2-stat-card-label {
+  display: block; font-family: var(--v2-font-label); font-size: 10px; color: var(--v2-on-surface-variant); letter-spacing: 0.2em;
+}
+
+.v2-stat-card-val { font-size: 24px; font-weight: 700; color: var(--v2-primary); }
+.text-secondary { color: var(--v2-secondary); }
+
+.v2-damage-grid-section {
+  margin-top: 32px;
+  background-color: var(--v2-surface-container-low);
+  padding: 24px;
+  position: relative;
+}
+
+.v2-section-header-v2 { display: flex; justify-content: space-between; align-items: center; margin-bottom: 24px; }
+
+.v2-section-title-v2 {
+  font-weight: 700; color: var(--v2-primary); letter-spacing: 0.1em; font-size: 14px; text-transform: uppercase; display: flex; align-items: center; gap: 8px;
+}
+
+.v2-section-icon-v2 { font-size: 18px; }
+
+.v2-warning-pulse { font-size: 10px; color: var(--v2-secondary); font-family: var(--v2-font-label); animation: v2-pulse 2s infinite; }
+
+@keyframes v2-pulse { 0% { opacity: 1; } 50% { opacity: 0.5; } 100% { opacity: 1; } }
+
+.v2-hull-grid-container { display: flex; flex-direction: column; align-items: center; gap: 8px; }
+.v2-hull-row { display: flex; gap: 8px; }
+
+.v2-hull-cell {
+  width: 48px; height: 48px; border-width: 1px; border-style: solid; display: flex; align-items: center; justify-content: center;
+}
+
+.cell-ok { background-color: rgba(79, 215, 240, 0.1); border-color: rgba(79, 215, 240, 0.3); }
+.cell-empty { background-color: var(--v2-surface-container-highest); border-color: rgba(79, 215, 240, 0.1); }
+
+.v2-cell-icon { color: var(--v2-secondary); opacity: 0.5; font-size: 24px; }
+
+.v2-hull-stack { display: flex; flex-direction: column; align-items: center; gap: 4px; }
+.v2-hull-label { font-size: 10px; color: var(--v2-on-surface-variant); font-weight: 700; }
+
+.v2-grid-underglow {
+  position: absolute; bottom: 0; left: 0; width: 100%; height: 4px; background: linear-gradient(to right, transparent, rgba(79, 215, 240, 0.2), transparent);
+}
+
+.v2-combat-systems { margin-top: 32px; padding: 0 16px; display: flex; flex-direction: column; gap: 32px; }
+
+.v2-system-group-label { font-size: 10px; color: var(--v2-on-surface-variant); margin-bottom: 12px; letter-spacing: 0.3em; text-transform: uppercase; }
+
+.v2-directives-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+
+.v2-directive-btn {
+  font-family: var(--v2-font-label); font-size: 12px; padding: 12px 16px; display: flex; align-items: center; justify-content: space-between; border: none; cursor: pointer;
+}
+
+.btn-primary-v2 { background-color: var(--v2-primary); color: var(--v2-on-primary); border-left: 4px solid #a5f3fc; }
+.btn-outline-v2 { background-color: var(--v2-surface-container-high); color: var(--v2-on-surface); border-left: 4px solid var(--v2-outline-variant); }
+
+.v2-directive-icon { font-size: 16px; }
+
+.v2-weapons-stack { display: flex; flex-direction: column; gap: 8px; }
+
+.v2-weapon-item-v2 {
+  background-color: var(--v2-surface-container); padding: 16px; display: flex; justify-content: space-between; align-items: center; border: 1px solid transparent;
+}
+
+.v2-weapon-item-v2.border-offline { border-color: rgba(255, 182, 139, 0.2); }
+
+.v2-weapon-name-v2 { display: block; font-weight: 700; font-size: 14px; text-transform: uppercase; }
+.text-primary { color: var(--v2-primary); }
+.text-secondary { color: var(--v2-secondary); }
+
+.v2-weapon-stats-v2 { font-size: 10px; color: var(--v2-on-surface-variant); text-transform: uppercase; }
+
+.v2-weapon-status-box { display: flex; align-items: center; gap: 8px; }
+
+.v2-offline-tag { font-size: 8px; color: var(--v2-secondary); text-transform: uppercase; }
+.v2-system-icon { color: rgba(79, 215, 240, 0.4); font-size: 20px; }
+
+.v2-status-dot { width: 8px; height: 8px; }
+.bg-secondary-dim { background-color: var(--v2-secondary); opacity: 0.2; }
+.bg-primary { background-color: var(--v2-primary); }
+
+.v2-abilities-section { margin-top: 32px; padding: 0 16px; }
+
+.v2-abilities-wrap { display: flex; flex-wrap: wrap; gap: 8px; }
+
+.v2-ability-chip {
+  padding: 4px 12px; font-family: var(--v2-font-label); font-size: 10px; border-width: 1px; border-style: solid;
+}
+
+.v2-ability-chip.primary { background-color: var(--v2-surface-container-highest); color: var(--v2-primary); border-color: rgba(79, 215, 240, 0.2); }
+.v2-ability-chip.secondary { background-color: var(--v2-surface-container-highest); color: var(--v2-secondary); border-color: rgba(255, 182, 139, 0.2); }
+</style>

--- a/src/views/v2/warhacker/WarhackerLayout.vue
+++ b/src/views/v2/warhacker/WarhackerLayout.vue
@@ -1,0 +1,286 @@
+<template>
+  <div class="v2-theme warhacker-layout">
+    <!-- TopAppBar -->
+    <header class="v2-header warhacker-header">
+      <div class="v2-header-left">
+        <span class="material-symbols-outlined v2-header-icon">radar</span>
+        <span class="font-headline warhacker-logo">WARHACKER_HUD</span>
+      </div>
+      <div class="hidden-lg-down v2-header-center">
+        <div class="v2-header-stat">
+          <span class="font-label v2-stat-tag">VANGUARD-79</span>
+          <div class="font-headline v2-stat-time">52:14</div>
+        </div>
+        <div class="v2-header-round">
+          <span class="font-label v2-round-tag">Round 3</span>
+          <div class="font-headline v2-round-status">Active Turn</div>
+        </div>
+      </div>
+      <div class="v2-header-right">
+        <span class="material-symbols-outlined">signal_cellular_alt</span>
+        <span class="material-symbols-outlined v2-cursor-pointer">settings</span>
+      </div>
+    </header>
+
+    <!-- SideNavBar (Desktop) -->
+    <aside class="v2-aside hidden-md-down warhacker-aside">
+      <div class="v2-aside-profile">
+        <div class="v2-profile-box">
+          <div class="v2-profile-avatar">
+             <span class="material-symbols-outlined v2-avatar-icon">account_circle</span>
+          </div>
+          <div>
+            <div class="font-headline v2-profile-name">STRATOS-01</div>
+            <div class="font-label v2-profile-phase">Phase: Engaged</div>
+          </div>
+        </div>
+      </div>
+      <nav class="v2-side-nav">
+        <router-link to="/v2/warhacker/home" class="warhacker-side-link" active-class="active">
+          <span class="material-symbols-outlined">grid_view</span>
+          <span class="font-label">Competitive View</span>
+        </router-link>
+        <router-link to="/v2/warhacker/factions" class="warhacker-side-link" active-class="active">
+          <span class="material-symbols-outlined">groups</span>
+          <span class="font-label">Factions</span>
+        </router-link>
+        <router-link to="/v2/warhacker/builder" class="warhacker-side-link" active-class="active">
+          <span class="material-symbols-outlined">format_list_bulleted</span>
+          <span class="font-label">Army Lists</span>
+        </router-link>
+        <router-link to="/v2/warhacker/intel" class="warhacker-side-link" active-class="active">
+          <span class="material-symbols-outlined">query_stats</span>
+          <span class="font-label">Intel</span>
+        </router-link>
+      </nav>
+      <div class="v2-aside-footer">
+        <button class="v2-button warhacker-action-button">
+          END ACTIVE TURN
+        </button>
+      </div>
+    </aside>
+
+    <!-- Main Content -->
+    <main class="v2-main warhacker-main">
+      <router-view />
+    </main>
+
+    <!-- BottomNavBar (Mobile) -->
+    <nav class="warhacker-bottom-nav md-hidden">
+      <router-link to="/v2/warhacker/factions" class="warhacker-bottom-link" active-class="active">
+        <span class="material-symbols-outlined">groups</span>
+        <span class="font-headline">Factions</span>
+      </router-link>
+      <router-link to="/v2/warhacker/builder" class="warhacker-bottom-link" active-class="active">
+        <span class="material-symbols-outlined">format_list_bulleted</span>
+        <span class="font-headline">Army</span>
+      </router-link>
+      <router-link to="/v2/warhacker/intel" class="warhacker-bottom-link" active-class="active">
+        <span class="material-symbols-outlined">query_stats</span>
+        <span class="font-headline">Intel</span>
+      </router-link>
+      <router-link to="/v2/warhacker/home" class="warhacker-bottom-link" active-class="active">
+        <span class="material-symbols-outlined">history_edu</span>
+        <span class="font-headline">Logs</span>
+      </router-link>
+    </nav>
+
+    <!-- UI Overlay elements -->
+    <div class="warhacker-overlay-frame"></div>
+  </div>
+</template>
+
+<style>
+@import '@/style.v2.css';
+@import '@/wardice.app.v2.css';
+</style>
+
+<style scoped>
+.warhacker-layout {
+  display: flex;
+  flex-direction: column;
+  background: radial-gradient(circle at 50% -20%, #05222f 0%, #001620 70%);
+}
+
+.warhacker-header {
+  background-color: rgba(8, 51, 68, 0.2);
+  backdrop-filter: blur(24px);
+  border-bottom: 2px solid rgba(79, 215, 240, 0.3);
+  box-shadow: 0 0 20px rgba(0, 178, 202, 0.15);
+}
+
+.v2-header-left { display: flex; align-items: center; gap: 12px; }
+.v2-header-icon { color: var(--v2-primary); }
+
+.warhacker-logo {
+  font-size: 20px;
+  font-weight: 900;
+  letter-spacing: 0.2em;
+  color: var(--v2-primary);
+  filter: drop-shadow(0 0 8px rgba(79, 215, 240, 0.6));
+  text-transform: uppercase;
+}
+
+.v2-header-center {
+  display: flex;
+  align-items: center;
+  gap: 32px;
+  background-color: var(--v2-surface-container-low);
+  border-left: 1px solid rgba(134, 147, 150, 0.2);
+  border-right: 1px solid rgba(134, 147, 150, 0.2);
+  padding: 0 32px;
+  height: 100%;
+}
+
+.v2-header-stat { display: flex; flex-direction: column; align-items: center; }
+.v2-stat-tag { font-size: 8px; color: var(--v2-primary); text-transform: uppercase; letter-spacing: 0.1em; }
+.v2-stat-time { font-size: 20px; font-weight: 700; color: var(--v2-primary); }
+
+.v2-header-round {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0 24px;
+  border-left: 1px solid rgba(134, 147, 150, 0.1);
+  border-right: 1px solid rgba(134, 147, 150, 0.1);
+}
+.v2-round-tag { font-size: 8px; color: var(--v2-outline); text-transform: uppercase; letter-spacing: 0.2em; }
+.v2-round-status { font-size: 12px; font-weight: 900; color: var(--v2-tertiary); letter-spacing: 0.1em; text-transform: uppercase; }
+
+.v2-header-right { display: flex; align-items: center; gap: 16px; color: var(--v2-primary); }
+.v2-cursor-pointer { cursor: pointer; }
+
+.warhacker-aside {
+  background-color: rgba(2, 6, 23, 0.4);
+  backdrop-filter: blur(32px);
+  border-right: 1px solid rgba(79, 215, 240, 0.2);
+}
+
+.v2-aside-profile { margin-bottom: 32px; padding: 0 8px; }
+.v2-profile-box { display: flex; align-items: center; gap: 12px; margin-bottom: 8px; }
+.v2-profile-avatar { width: 40px; height: 40px; border: 1px solid rgba(79, 215, 240, 0.5); display: flex; align-items: center; justify-content: center; padding: 4px; }
+.v2-avatar-icon { color: var(--v2-primary); }
+.v2-profile-name { color: var(--v2-primary); font-weight: 700; font-size: 14px; letter-spacing: 0.1em; }
+.v2-profile-phase { font-size: 10px; color: rgba(79, 215, 240, 0.6); text-transform: uppercase; }
+
+.v2-side-nav { flex-grow: 1; display: flex; flex-direction: column; gap: 4px; }
+
+.warhacker-side-link {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  color: #155e75;
+  text-decoration: none;
+  font-size: 12px;
+  text-transform: uppercase;
+  transition: all 0.3s ease;
+}
+
+.warhacker-side-link:hover {
+  background-color: rgba(8, 51, 68, 0.3);
+  color: #a5f3fc;
+}
+
+.warhacker-side-link.active {
+  background-color: rgba(79, 215, 240, 0.1);
+  color: var(--v2-primary);
+  border-right: 4px solid var(--v2-primary);
+}
+
+.v2-aside-footer { margin-top: auto; padding: 0 8px; }
+
+.warhacker-action-button {
+  background-color: var(--v2-primary-container);
+  color: white;
+  padding: 12px;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.2em;
+  border: none;
+  cursor: pointer;
+  width: 100%;
+}
+
+.warhacker-action-button:hover {
+  background-color: var(--v2-primary);
+}
+
+.warhacker-main {
+  background: transparent;
+  padding-top: 64px;
+}
+
+.warhacker-bottom-nav {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 80px;
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  background-color: rgba(8, 51, 68, 0.4);
+  backdrop-filter: blur(32px);
+  border-top: 1px solid rgba(79, 215, 240, 0.2);
+  padding-bottom: env(safe-area-inset-bottom);
+  box-sizing: border-box;
+  z-index: 50;
+}
+
+.warhacker-bottom-link {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  color: rgba(21, 94, 117, 0.8);
+  text-decoration: none;
+  padding: 4px 8px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  transition: all 0.3s ease;
+}
+
+.warhacker-bottom-link.active {
+  color: var(--v2-primary);
+  border-top: 2px solid var(--v2-primary);
+  background-color: rgba(79, 215, 240, 0.05);
+}
+
+.warhacker-overlay-frame {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  border: 12px solid rgba(79, 215, 240, 0.05);
+  z-index: 60;
+}
+
+@media (min-width: 768px) {
+  .warhacker-main {
+    margin-left: 256px !important;
+  }
+}
+
+@media (max-width: 1023px) {
+  .hidden-lg-down {
+    display: none !important;
+  }
+}
+
+@media (max-width: 767px) {
+  .md-hidden {
+    display: flex !important;
+  }
+  .hidden-md-down {
+    display: none !important;
+  }
+}
+
+@media (min-width: 768px) {
+  .md-hidden {
+    display: none !important;
+  }
+}
+</style>

--- a/src/wardice.app.v2.css
+++ b/src/wardice.app.v2.css
@@ -1,0 +1,188 @@
+/* Layout Components */
+.v2-header {
+  position: fixed;
+  top: 0;
+  width: 100%;
+  height: 64px;
+  z-index: 50;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 24px;
+  box-sizing: border-box;
+}
+
+.v2-aside {
+  position: fixed;
+  left: 0;
+  top: 0;
+  height: 100%;
+  width: 256px;
+  z-index: 40;
+  display: flex;
+  flex-direction: column;
+  padding-top: 80px;
+  padding-bottom: 32px;
+  padding-left: 16px;
+  padding-right: 16px;
+  box-sizing: border-box;
+}
+
+.v2-main {
+  min-height: 100vh;
+  box-sizing: border-box;
+}
+
+/* Glass Panels */
+.glass-panel {
+  backdrop-filter: blur(12px);
+  background: rgba(5, 34, 47, 0.7);
+}
+
+.tonal-shift-glass {
+  background: linear-gradient(180deg, rgba(1, 30, 42, 0.9) 0%, rgba(0, 22, 32, 0.8) 100%);
+}
+
+.hud-glass {
+  backdrop-filter: blur(12px);
+  background: linear-gradient(135deg, rgba(30, 56, 69, 0.4) 0%, rgba(5, 34, 47, 0.6) 100%);
+}
+
+/* Effects */
+.inner-glow {
+  box-shadow: inset 0 0 15px rgba(79, 215, 240, 0.1);
+}
+
+.inner-glow-asymmetry {
+  box-shadow: inset 1px 0px 0px 0px rgba(79, 215, 240, 0.1);
+}
+
+.chiseled-top {
+  border-top: 1px solid rgba(79, 215, 240, 0.3);
+}
+
+.scanline {
+  background: linear-gradient(to bottom, transparent 50%, rgba(79, 215, 240, 0.05) 50%);
+  background-size: 100% 4px;
+  pointer-events: none;
+}
+
+.v2-scanline-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  background: rgba(79, 215, 240, 0.1);
+  pointer-events: none;
+  z-index: 100;
+}
+
+.flicker-alert {
+  animation: v2-flicker 2s infinite;
+}
+
+@keyframes v2-flicker {
+  0%, 18%, 22%, 25%, 53%, 57%, 100% { opacity: 1; }
+  20%, 24%, 55% { opacity: 0.4; }
+}
+
+/* UI Elements */
+.v2-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 12px 16px;
+  font-family: var(--v2-font-label);
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  transition: all 0.3s ease;
+  cursor: pointer;
+  border: none;
+}
+
+.v2-button-primary {
+  background-color: var(--v2-primary);
+  color: var(--v2-on-primary);
+}
+
+.v2-button-primary:hover {
+  box-shadow: 0 0 20px rgba(79, 215, 240, 0.4);
+}
+
+.v2-button-outline {
+  background-color: transparent;
+  border: 1px solid var(--v2-outline-variant);
+  color: var(--v2-on-surface);
+}
+
+.v2-button-outline:hover {
+  background-color: var(--v2-primary);
+  color: var(--v2-on-primary);
+  border-color: var(--v2-primary);
+}
+
+/* Cards & Grid */
+.v2-card {
+  position: relative;
+  overflow: hidden;
+  background-color: var(--v2-surface-container-low);
+  transition: all 0.5s ease;
+}
+
+.v2-bento-grid {
+  display: grid;
+  gap: 24px;
+}
+
+/* Faction Specifics */
+.faction-badge {
+  padding: 12px;
+  font-weight: 900;
+  font-size: 20px;
+  line-height: 1;
+}
+
+/* HUD Grid */
+.v2-grid-cell {
+  width: 8px;
+  height: 8px;
+  background: rgba(134, 147, 150, 0.2);
+  border: 1px solid rgba(79, 215, 240, 0.1);
+}
+
+.v2-grid-cell.filled {
+  background: var(--v2-primary);
+  box-shadow: 0 0 5px rgba(79, 215, 240, 0.8);
+}
+
+.v2-grid-cell.damaged {
+  background: var(--v2-error);
+}
+
+.v2-grid-cell.opponent-filled {
+  background: var(--v2-secondary);
+  box-shadow: 0 0 5px rgba(255, 182, 139, 0.8);
+}
+
+/* Map Components */
+.tactical-map-container {
+  background-color: var(--v2-surface-container-lowest);
+  border: 1px solid rgba(79, 215, 240, 0.3);
+  position: relative;
+  overflow: hidden;
+}
+
+.map-overlay-layer {
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(0deg, transparent, transparent 1px, rgba(79, 215, 240, 0.05) 1px, rgba(79, 215, 240, 0.05) 2px);
+  pointer-events: none;
+}
+
+/* Stat Blocks */
+.unit-stat-hex {
+  clip-path: polygon(25% 0%, 75% 0%, 100% 50%, 75% 100%, 25% 100%, 0% 50%);
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,8 +6,11 @@ import path from 'path'
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  test: {
+    environment: 'jsdom'
+  },
   server: {
-    host: 'wardice.local'
+    host: '0.0.0.0'
   },
   resolve: {
     alias: {


### PR DESCRIPTION
This PR introduces 12 new pages under the /v2 route, featuring two distinct UI themes: Tactical Command (desktop-focused) and Warhacker HUD (mobile-focused). The implementation uses standard CSS and CSS variables for theming, ensuring no dependency on Tailwind CSS. It includes responsive layouts, unit detail views with damage grids, and comprehensive verification via unit tests and automated Playwright screenshots.

Tema: Tactical Command (Enfoque Desktop)
Este tema utiliza una disposición con barra lateral y un diseño de "consola de mando".

Facciones: http://localhost:5173/v2/tactical/factions
Constructor de Ejército: http://localhost:5173/v2/tactical/builder
Resumen de Batallón: http://localhost:5173/v2/tactical/summary
Detalle de Unidad (Estándar): http://localhost:5173/v2/tactical/unit
Detalle de Unidad (Cuadrícula Irregular): http://localhost:5173/v2/tactical/unit-v2
Vista de Juego Activo: http://localhost:5173/v2/tactical/game
Tema: Warhacker HUD (Enfoque Mobile/Cyberpunk)
Este tema utiliza una estética HUD y navegación inferior. La página de inicio es responsiva (cambia de diseño según el tamaño de la pantalla).

Inicio (Comando Móvil/Desktop): http://localhost:5173/v2/warhacker/home
Selección de Facción: http://localhost:5173/v2/warhacker/factions
Constructor de Ejército: http://localhost:5173/v2/warhacker/builder
Detalle de Unidad HUD: http://localhost:5173/v2/warhacker/unit
Intel / Listado de Unidades: http://localhost:5173/v2/warhacker/intel

---
*PR created automatically by Jules for task [9309262292681329578](https://jules.google.com/task/9309262292681329578) started by @isorna*